### PR TITLE
Infer `accessibility` and `numberOfPages` metadata

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,3 +10,43 @@ The `rwp` command provides utilities to parse and generate Web Publications.
 
 To install `rwp` in `~/go/bin`, run `make install`. Use `make build` to build the binary in the current directory.
 
+### Generating a Readium Web Publication Manifest
+
+The `rwp manifest` command will parse a publication file (such as EPUB, PDF, audiobook, etc.) and build a Readium Web Publication Manifest for it. The JSON manifest is
+printed to stdout.
+
+Examples:
+
+* Print out a compact JSON RWPM.
+    ```sh
+    rwp manifest publication.epub
+    ```
+* Pretty-print a JSON RWPM using two-space indent.
+    ```sh
+    rwp manifest --indent "  " publication.epub
+    ```
+* Extract the publication title with `jq`.
+    ```sh
+    rwp manifest publication.epub | jq -r .metadata.title
+    ```
+
+#### Accessibility inference
+
+`rwp manifest` can infer additional accessibility metadata when they are missing, with the `--infer-a11y` flag.
+
+```sh
+rwp manifest --infer-a11y publication.epub  | jq .metadata.accessibility
+```
+
+##### Inferred metadata
+
+| Key | Value | Inferred? |
+|-----|-------|-----------|
+| `accessMode` | `auditory` | If the publication contains a reference to an audio or video resource (inspect `resources` and `readingOrder` in RWPM) |
+| `accessMode` | `visual` | If the publications contains a reference to an image or a video resource (inspect `resources` and `readingOrder` in RWPM) |
+| `accessModeSufficient` | `textual` | If the publication is partially or fully accessible (WCAG A or above)<br>Or if the publication does not contain any image, audio or video resource (inspect "resources" and "readingOrder" in RWPM)<br>Or if the only image available can be identified as a cover |
+| `feature` | `displayTransformability` | If the publication is fully accessible (WCAG AA or above)<br>:warning: This property should only be inferred for reflowable EPUB files as it doesn't apply to other formats (FXL, PDF, audiobooks, CBZ/CBR). |
+| `feature` | `printPageNumbers` | If the publications contains a page list (check for the presence of a `pageList` collection in RWPM) |
+| `feature` | `tableOfContents` | If the publications contains a table of contents (check for the presence of a `toc` collection in RWPM) |
+| `feature` | `MathML` | If the publication contains any resource with MathML (check for the presence of the `contains` property where the value is `mathml` in `readingOrder` or `resources` in RWPM) |
+| `feature` | `synchronizedAudioText` | If the publication contains any reference to Media Overlays (TBD in RWPM) |

--- a/cmd/rwp/cmd/manifest.go
+++ b/cmd/rwp/cmd/manifest.go
@@ -11,8 +11,11 @@ import (
 	"github.com/spf13/cobra"
 )
 
-// Indentation used to pretty-print
+// Indentation used to pretty-print.
 var indentFlag string
+
+// Infer accessibility metadata.
+var inferA11yFlag bool
 
 var manifestCmd = &cobra.Command{
 	Use:   "manifest <pub-path>",
@@ -24,10 +27,10 @@ and build a Readium Web Publication Manifest for it. The JSON manifest is
 printed to stdout.
 
 Examples:
-  Print out a minimal JSON RWPM. 
+  Print out a compact JSON RWPM. 
   $ rwp manifest publication.epub
 
-  Pretty-print a JSON RWPM using tow-space indent.
+  Pretty-print a JSON RWPM using two-space indent.
   $ rwp manifest --indent "  " publication.epub
 
   Extract the publication title with ` + "`jq`" + `.
@@ -43,7 +46,9 @@ Examples:
 	},
 	RunE: func(cmd *cobra.Command, args []string) error {
 		path := filepath.Clean(args[0])
-		pub, err := streamer.New(streamer.Config{}).Open(
+		pub, err := streamer.New(streamer.Config{
+			InferA11yMetadata: inferA11yFlag,
+		}).Open(
 			asset.File(path), "",
 		)
 		if err != nil {
@@ -68,4 +73,5 @@ Examples:
 func init() {
 	rootCmd.AddCommand(manifestCmd)
 	manifestCmd.Flags().StringVarP(&indentFlag, "indent", "i", "", "Indentation used to pretty-print")
+	manifestCmd.Flags().BoolVar(&inferA11yFlag, "infer-a11y", false, "Infer accessibility metadata")
 }

--- a/cmd/rwp/cmd/manifest.go
+++ b/cmd/rwp/cmd/manifest.go
@@ -17,6 +17,9 @@ var indentFlag string
 // Infer accessibility metadata.
 var inferA11yFlag bool
 
+// Infer the number of pages from the generated position list.
+var inferPageCountFlag bool
+
 var manifestCmd = &cobra.Command{
 	Use:   "manifest <pub-path>",
 	Short: "Generate a Readium Web Publication Manifest for a publication",
@@ -48,6 +51,7 @@ Examples:
 		path := filepath.Clean(args[0])
 		pub, err := streamer.New(streamer.Config{
 			InferA11yMetadata: inferA11yFlag,
+			InferPageCount:    inferPageCountFlag,
 		}).Open(
 			asset.File(path), "",
 		)
@@ -74,4 +78,5 @@ func init() {
 	rootCmd.AddCommand(manifestCmd)
 	manifestCmd.Flags().StringVarP(&indentFlag, "indent", "i", "", "Indentation used to pretty-print")
 	manifestCmd.Flags().BoolVar(&inferA11yFlag, "infer-a11y", false, "Infer accessibility metadata")
+	manifestCmd.Flags().BoolVar(&inferPageCountFlag, "infer-page-count", false, "Infer the number of pages from the generated position list.")
 }

--- a/pkg/internal/extensions/string.go
+++ b/pkg/internal/extensions/string.go
@@ -60,9 +60,9 @@ func ParseDate(raw string) *time.Time {
 	return &t
 }
 
-func Contains(strings []string, s string) bool {
-	for _, v := range strings {
-		if v == s {
+func Contains[T comparable](list []T, element T) bool {
+	for _, v := range list {
+		if v == element {
 			return true
 		}
 	}

--- a/pkg/manifest/a11y.go
+++ b/pkg/manifest/a11y.go
@@ -127,7 +127,7 @@ const (
 	// EPUB Accessibility 1.0 - WCAG 2.0 Level AA
 	EPUBA11y10WCAG20AA A11yProfile = "http://www.idpf.org/epub/a11y/accessibility-20170105.html#wcag-aa"
 	// EPUB Accessibility 1.0 - WCAG 2.0 Level AAA
-	EPUBA11yWCAG20AAA A11yProfile = "http://www.idpf.org/epub/a11y/accessibility-20170105.html#wcag-aaa"
+	EPUBA11y10WCAG20AAA A11yProfile = "http://www.idpf.org/epub/a11y/accessibility-20170105.html#wcag-aaa"
 )
 
 func A11yProfilesFromStrings(strings []string) []A11yProfile {

--- a/pkg/parser/epub/metadata.go
+++ b/pkg/parser/epub/metadata.go
@@ -1017,6 +1017,17 @@ func (m *PubMetadataAdapter) OtherMetadata() map[string]interface{} {
 			VocabularyRendition + "spread":      {},
 			VocabularyRendition + "orientation": {},
 			VocabularyRendition + "layout":      {},
+
+			VocabularyDCTerms + "conformsto":          {},
+			VocabularyDCTerms + "conformsTo":          {},
+			VocabularyA11Y + "certifiedBy":            {},
+			VocabularyA11Y + "certifierCredential":    {},
+			VocabularyA11Y + "certifierReport":        {},
+			VocabularySchema + "accessibilitySummary": {},
+			VocabularySchema + "accessMode":           {},
+			VocabularySchema + "accessModeSufficient": {},
+			VocabularySchema + "accessibilityFeature": {},
+			VocabularySchema + "accessibilityHazard":  {},
 		}
 
 		m._otherMetadata = make(map[string]interface{})

--- a/pkg/parser/epub/metadata.go
+++ b/pkg/parser/epub/metadata.go
@@ -692,7 +692,7 @@ func a11yProfile(value string) manifest.A11yProfile {
 		"http://www.idpf.org/epub/a11y/accessibility-20170105.html#wcag-aaa",
 		"https://idpf.org/epub/a11y/accessibility-20170105.html#wcag-aaa",
 		"https://www.idpf.org/epub/a11y/accessibility-20170105.html#wcag-aaa":
-		return manifest.EPUBA11yWCAG20AAA
+		return manifest.EPUBA11y10WCAG20AAA
 
 	default:
 		return ""

--- a/pkg/pub/publication.go
+++ b/pkg/pub/publication.go
@@ -159,18 +159,18 @@ func NewBuilder(m manifest.Manifest, f fetcher.Fetcher, b *ServicesBuilder) *Bui
 		b = NewServicesBuilder(nil)
 	}
 	return &Builder{
-		manifest:        m,
-		fetcher:         f,
-		servicesBuilder: *b,
+		Manifest:        m,
+		Fetcher:         f,
+		ServicesBuilder: *b,
 	}
 }
 
 type Builder struct {
-	manifest        manifest.Manifest
-	fetcher         fetcher.Fetcher
-	servicesBuilder ServicesBuilder
+	Manifest        manifest.Manifest
+	Fetcher         fetcher.Fetcher
+	ServicesBuilder ServicesBuilder
 }
 
 func (b Builder) Build() *Publication {
-	return New(b.manifest, b.fetcher, &b.servicesBuilder)
+	return New(b.Manifest, b.Fetcher, &b.ServicesBuilder)
 }

--- a/pkg/streamer/a11y_infer.go
+++ b/pkg/streamer/a11y_infer.go
@@ -1,0 +1,118 @@
+package streamer
+
+import (
+	"github.com/readium/go-toolkit/pkg/internal/extensions"
+	"github.com/readium/go-toolkit/pkg/manifest"
+	"github.com/readium/go-toolkit/pkg/mediatype"
+)
+
+func inferA11yMetadataFromManifest(mf manifest.Manifest) *manifest.A11y {
+	var a11y manifest.A11y
+	if mf.Metadata.Accessibility != nil {
+		a11y = *mf.Metadata.Accessibility
+	} else {
+		a11y = manifest.NewA11y()
+	}
+
+	accessModes := a11y.AccessModes
+	accessModesSufficient := a11y.AccessModesSufficient
+	features := a11y.Features
+
+	addFeature := func(f manifest.A11yFeature) {
+		if !extensions.Contains(features, f) {
+			features = append(features, f)
+		}
+	}
+
+	allResources := append(mf.ReadingOrder, mf.Resources...)
+
+	if len(accessModes) == 0 {
+		for _, link := range allResources {
+			if link.MediaType().IsAudio() || link.MediaType().IsVideo() {
+				accessModes = append(accessModes, manifest.A11yAccessModeAuditory)
+				break
+			}
+		}
+
+		for _, link := range allResources {
+			if link.MediaType().IsBitmap() || link.MediaType().IsVideo() {
+				accessModes = append(accessModes, manifest.A11yAccessModeVisual)
+				break
+			}
+		}
+	}
+
+	if len(accessModesSufficient) == 0 {
+		setTextual := false
+
+		for _, profile := range a11y.ConformsTo {
+			if profile == manifest.EPUBA11y10WCAG20A ||
+				profile == manifest.EPUBA11y10WCAG20AA ||
+				profile == manifest.EPUBA11y10WCAG20AAA {
+				setTextual = true
+				break
+			}
+		}
+
+		if !setTextual {
+			setTextual = true
+			for _, link := range allResources {
+				mt := link.MediaType()
+				if mt.IsAudio() ||
+					mt.IsVideo() ||
+					(mt.IsBitmap() && !extensions.Contains(link.Rels, "cover")) ||
+					mt.Matches(&mediatype.PDF) {
+
+					setTextual = false
+					break
+				}
+			}
+		}
+
+		if setTextual {
+			accessModesSufficient = append(
+				accessModesSufficient,
+				[]manifest.A11yPrimaryAccessMode{manifest.A11yPrimaryAccessModeTextual},
+			)
+		}
+
+		if allResources.AllAreAudio() {
+			accessModesSufficient = append(
+				accessModesSufficient,
+				[]manifest.A11yPrimaryAccessMode{manifest.A11yPrimaryAccessModeAuditory},
+			)
+		}
+	}
+
+	if mf.TableOfContents != nil && len(mf.TableOfContents) > 0 {
+		addFeature(manifest.A11yFeatureTableOfContents)
+	}
+
+	if mf.ConformsTo(manifest.ProfileEPUB) {
+		if _, hasPageList := mf.Subcollections["pageList"]; hasPageList {
+			addFeature(manifest.A11yFeaturePrintPageNumbers)
+		}
+
+		for _, link := range allResources {
+			if extensions.Contains(link.Properties.Contains(), "mathml") {
+				addFeature(manifest.A11yFeatureMathML)
+				break
+			}
+		}
+
+		if mf.Metadata.Presentation != nil && *mf.Metadata.Presentation.Layout == manifest.EPUBLayoutReflowable {
+			if extensions.Contains(a11y.ConformsTo, manifest.EPUBA11y10WCAG20AA) ||
+				extensions.Contains(a11y.ConformsTo, manifest.EPUBA11y10WCAG20AAA) {
+				addFeature(manifest.A11yFeatureDisplayTransformability)
+			}
+		}
+	}
+
+	a11y.AccessModes = accessModes
+	a11y.AccessModesSufficient = accessModesSufficient
+	a11y.Features = features
+	if a11y.IsEmpty() {
+		return nil
+	}
+	return &a11y
+}

--- a/pkg/streamer/a11y_infer_test.go
+++ b/pkg/streamer/a11y_infer_test.go
@@ -1,0 +1,264 @@
+package streamer
+
+import (
+	"testing"
+
+	"github.com/readium/go-toolkit/pkg/manifest"
+	"github.com/readium/go-toolkit/pkg/mediatype"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestReturnsAugmentedA11yMetadataWithInference(t *testing.T) {
+	a11y := manifest.NewA11y()
+	a11y.ConformsTo = []manifest.A11yProfile{"unknown"}
+
+	m := manifest.Manifest{
+		Metadata: manifest.Metadata{
+			Accessibility: &a11y,
+		},
+		ReadingOrder: []manifest.Link{
+			newLink(mediatype.HTML, "html"),
+		},
+	}
+
+	inferreddA11y := a11y
+	inferreddA11y.AccessModesSufficient = [][]manifest.A11yPrimaryAccessMode{{manifest.A11yPrimaryAccessModeTextual}}
+
+	res := inferA11yMetadataFromManifest(m)
+	assert.Equal(t, &inferreddA11y, res)
+
+	// Original manifest should not be modified.
+	assert.Equal(t, &a11y, m.Metadata.Accessibility)
+}
+
+func newLink(mt mediatype.MediaType, extension string) manifest.Link {
+	return manifest.Link{
+		Href: "file." + extension,
+		Type: mt.String(),
+	}
+}
+
+// If the publication contains a reference to an audio or video resource
+// (inspect "resources" and "readingOrder" in RWPM).
+func TestInferAuditoryAccessMode(t *testing.T) {
+	assertAccessMode(t, manifest.A11yAccessModeAuditory, "mp3", mediatype.MP3)
+	assertAccessMode(t, manifest.A11yAccessModeAuditory, "mpeg", mediatype.MPEG)
+}
+
+// If the publications contains a reference to an image or a video resource
+// (inspect "resources" and "readingOrder" in RWPM)
+func TestInferVisualAccessMode(t *testing.T) {
+	assertAccessMode(t, manifest.A11yAccessModeVisual, "jpg", mediatype.JPEG)
+	assertAccessMode(t, manifest.A11yAccessModeVisual, "mpeg", mediatype.MPEG)
+}
+
+func assertAccessMode(t *testing.T, accessMode manifest.A11yAccessMode, extension string, mt mediatype.MediaType) {
+	testManifest := func(m manifest.Manifest) {
+		res := inferA11yMetadataFromManifest(m)
+		assert.NotNil(t, res)
+		assert.Contains(t, res.AccessModes, accessMode)
+	}
+
+	link := newLink(mt, extension)
+
+	testManifest(manifest.Manifest{
+		ReadingOrder: []manifest.Link{link},
+	})
+	testManifest(manifest.Manifest{
+		Resources: []manifest.Link{link},
+	})
+}
+
+// If the publication is partially or fully accessible (WCAG A or above)
+func TestInferTextualAccessModeSufficientFromProfile(t *testing.T) {
+	test := func(profile manifest.A11yProfile) {
+		a11y := manifest.NewA11y()
+		a11y.ConformsTo = []manifest.A11yProfile{profile}
+		m := manifest.Manifest{
+			Metadata: manifest.Metadata{
+				Accessibility: &a11y,
+			},
+		}
+		res := inferA11yMetadataFromManifest(m)
+		assert.NotNil(t, res)
+		assert.Contains(t, res.AccessModesSufficient, []manifest.A11yPrimaryAccessMode{manifest.A11yPrimaryAccessModeTextual})
+	}
+
+	test(manifest.EPUBA11y10WCAG20A)
+	test(manifest.EPUBA11y10WCAG20AA)
+	test(manifest.EPUBA11y10WCAG20AAA)
+}
+
+// Or if the publication does not contain any image, audio or video resource
+// (inspect "resources" and "readingOrder" in RWPM)
+func TestInferTextualAccessModeSufficientFromLackOfMedia(t *testing.T) {
+	testManifest := func(contains bool, m manifest.Manifest) {
+		res := inferA11yMetadataFromManifest(m)
+		assert.NotNil(t, res)
+		ams := []manifest.A11yPrimaryAccessMode{manifest.A11yPrimaryAccessModeTextual}
+
+		if contains {
+			assert.Contains(t, res.AccessModesSufficient, ams)
+		} else {
+			assert.NotContains(t, res.AccessModesSufficient, ams)
+		}
+	}
+
+	a11y := manifest.NewA11y()
+	a11y.ConformsTo = []manifest.A11yProfile{"unknown"}
+
+	testReadingOrder := func(contains bool, mt mediatype.MediaType, extension string) {
+		testManifest(contains, manifest.Manifest{
+			Metadata:     manifest.Metadata{Accessibility: &a11y},
+			ReadingOrder: []manifest.Link{newLink(mt, extension)},
+		})
+	}
+
+	testReadingOrder(true, mediatype.HTML, "html")
+	testReadingOrder(false, mediatype.JPEG, "jpg")
+	testReadingOrder(false, mediatype.MP3, "mp3")
+	testReadingOrder(false, mediatype.MPEG, "mpeg")
+	testReadingOrder(false, mediatype.PDF, "pdf")
+
+	testResources := func(contains bool, mt mediatype.MediaType, extension string) {
+		testManifest(contains, manifest.Manifest{
+			Metadata:  manifest.Metadata{Accessibility: &a11y},
+			Resources: []manifest.Link{newLink(mt, extension)},
+		})
+	}
+
+	testResources(true, mediatype.HTML, "html")
+	testResources(false, mediatype.JPEG, "jpg")
+	testResources(false, mediatype.MP3, "mp3")
+	testResources(false, mediatype.MPEG, "mpeg")
+	testResources(false, mediatype.PDF, "pdf")
+}
+
+// If the publication contains only references to audio resources (inspect "resources" and "readingOrder" in RWPM)
+func TestInferAuditoryAccessModeSufficient(t *testing.T) {
+	testManifest := func(contains bool, m manifest.Manifest) {
+		res := inferA11yMetadataFromManifest(m)
+		assert.NotNil(t, res)
+		ams := []manifest.A11yPrimaryAccessMode{manifest.A11yPrimaryAccessModeAuditory}
+
+		if contains {
+			assert.Contains(t, res.AccessModesSufficient, ams)
+		} else {
+			assert.NotContains(t, res.AccessModesSufficient, ams)
+		}
+	}
+
+	a11y := manifest.NewA11y()
+	a11y.ConformsTo = []manifest.A11yProfile{"unknown"}
+
+	testReadingOrder := func(contains bool, links ...manifest.Link) {
+		testManifest(contains, manifest.Manifest{
+			Metadata:     manifest.Metadata{Accessibility: &a11y},
+			ReadingOrder: links,
+		})
+	}
+
+	html := newLink(mediatype.HTML, "html")
+	mp3 := newLink(mediatype.MP3, "mp3")
+
+	testReadingOrder(false, html, html)
+	testReadingOrder(false, html, mp3)
+	testReadingOrder(true, mp3, mp3)
+
+	testResources := func(contains bool, links ...manifest.Link) {
+		testManifest(contains, manifest.Manifest{
+			Metadata:  manifest.Metadata{Accessibility: &a11y},
+			Resources: links,
+		})
+	}
+
+	testResources(false, html, html)
+	testResources(false, html, mp3)
+	testResources(true, mp3, mp3)
+}
+
+// If the publications contains a table of contents (check for the presence of
+// a "toc" collection in RWPM)
+func TestInferFeatureTableOfContents(t *testing.T) {
+	m := manifest.Manifest{
+		TableOfContents: []manifest.Link{newLink(mediatype.HTML, "html")},
+	}
+	assertFeature(t, m, manifest.A11yFeatureTableOfContents)
+}
+
+// If the publications contains a page list (check for the presence of a
+// "pageList" collection in RWPM)
+func TestInferFeaturePageList(t *testing.T) {
+	m := manifest.Manifest{
+		Metadata: manifest.Metadata{
+			ConformsTo: []manifest.Profile{manifest.ProfileEPUB},
+		},
+		Subcollections: map[string][]manifest.PublicationCollection{
+			"pageList": {
+				manifest.PublicationCollection{
+					Links: []manifest.Link{newLink(mediatype.HTML, "html")},
+				},
+			},
+		},
+		ReadingOrder: []manifest.Link{newLink(mediatype.HTML, "html")},
+	}
+	assertFeature(t, m, manifest.A11yFeaturePrintPageNumbers)
+}
+
+// If the publication contains any resource with MathML (check for the presence
+// of the "contains" property where the value is "mathml" in "readingOrder" or
+// "resources" in RWPM)
+func TestInferFeatureMathML(t *testing.T) {
+	link := newLink(mediatype.HTML, "html")
+	link.Properties = map[string]interface{}{
+		"contains": []string{"mathml"},
+	}
+	m := manifest.Manifest{
+		Metadata: manifest.Metadata{
+			ConformsTo: []manifest.Profile{manifest.ProfileEPUB},
+		},
+		ReadingOrder: []manifest.Link{link},
+	}
+	assertFeature(t, m, manifest.A11yFeatureMathML)
+}
+
+// If the publication is fully accessible (WCAG AA or above)
+//
+// This property should only be inferred for reflowable EPUB files as it
+// doesn't apply to other formats (FXL, PDF, audiobooks, CBZ/CBR).
+func TestInferFeatureDisplayTransformability(t *testing.T) {
+	test := func(contains bool, profile manifest.A11yProfile, layout manifest.EPUBLayout) {
+		a11y := manifest.NewA11y()
+		a11y.ConformsTo = []manifest.A11yProfile{profile}
+
+		m := manifest.Manifest{
+			Metadata: manifest.Metadata{
+				ConformsTo:    []manifest.Profile{manifest.ProfileEPUB},
+				Accessibility: &a11y,
+				Presentation: &manifest.Presentation{
+					Layout: &layout,
+				},
+			},
+			ReadingOrder: []manifest.Link{newLink(mediatype.HTML, "html")},
+		}
+
+		res := inferA11yMetadataFromManifest(m)
+		assert.NotNil(t, res)
+		if contains {
+			assert.Contains(t, res.Features, manifest.A11yFeatureDisplayTransformability)
+		} else {
+			assert.NotContains(t, res.Features, manifest.A11yFeatureDisplayTransformability)
+		}
+	}
+
+	test(false, manifest.EPUBA11y10WCAG20A, manifest.EPUBLayoutReflowable)
+	test(true, manifest.EPUBA11y10WCAG20AA, manifest.EPUBLayoutReflowable)
+	test(true, manifest.EPUBA11y10WCAG20AAA, manifest.EPUBLayoutReflowable)
+	test(false, manifest.EPUBA11y10WCAG20AAA, manifest.EPUBLayoutFixed)
+}
+
+func assertFeature(t *testing.T, m manifest.Manifest, feature manifest.A11yFeature) {
+	res := inferA11yMetadataFromManifest(m)
+	assert.NotNil(t, res)
+	assert.Contains(t, res.Features, feature)
+}


### PR DESCRIPTION
## `numberOfPages` inference

When the `metadata.numberOfPages` property is missing from the manifest, use the `--infer-page-count` flag to fill it using the generated position list.

## Accessibility metadata inference

`rwp manifest` can infer additional accessibility metadata when they are missing, with the `--infer-a11y` flag.

```sh
rwp manifest --infer-a11y publication.epub  | jq .metadata.accessibility
```

##### Inferred metadata

| Key | Value | Inferred? |
|-----|-------|-----------|
| `accessMode` | `auditory` | If the publication contains a reference to an audio or video resource (inspect `resources` and `readingOrder` in RWPM) |
| `accessMode` | `visual` | If the publications contains a reference to an image or a video resource (inspect `resources` and `readingOrder` in RWPM) |
| `accessModeSufficient` | `textual` | If the publication is partially or fully accessible (WCAG A or above)<br>Or if the publication does not contain any image, audio or video resource (inspect "resources" and "readingOrder" in RWPM)<br>Or if the only image available can be identified as a cover |
| `feature` | `displayTransformability` | If the publication is fully accessible (WCAG AA or above)<br>:warning: This property should only be inferred for reflowable EPUB files as it doesn't apply to other formats (FXL, PDF, audiobooks, CBZ/CBR). |
| `feature` | `printPageNumbers` | If the publications contains a page list (check for the presence of a `pageList` collection in RWPM) |
| `feature` | `tableOfContents` | If the publications contains a table of contents (check for the presence of a `toc` collection in RWPM) |
| `feature` | `MathML` | If the publication contains any resource with MathML (check for the presence of the `contains` property where the value is `mathml` in `readingOrder` or `resources` in RWPM) |
| `feature` | `synchronizedAudioText` | If the publication contains any reference to Media Overlays (TBD in RWPM) |