### PR TITLE
Add EPUB version metadata extension

### DIFF
--- a/pkg/parser/epub/factory.go
+++ b/pkg/parser/epub/factory.go
@@ -53,6 +53,7 @@ func (f PublicationFactory) Create() manifest.Manifest {
 
 	// Compute Metadata
 	metadata := f.pubMetadata.Metadata()
+	metadata.OtherMetadata[NamespaceOPF+"#version"] = f.PackageDocument.EPUBVersionString
 	metadataLinks := make([]manifest.Link, 0, len(links))
 	for _, link := range links {
 		metadataLinks = append(metadataLinks, mapEPUBLink(link))

--- a/pkg/parser/epub/metadata_test.go
+++ b/pkg/parser/epub/metadata_test.go
@@ -524,6 +524,7 @@ func TestMetadataOtherMetadata(t *testing.T) {
 			map[string]interface{}{"@value": "Web", "http://my.url/#scheme": "http"},
 			"Internet",
 		},
+		"http://www.idpf.org/2007/opf#version": "3.0",
 		"http://my.url/#property0": map[string]interface{}{
 			"@value": "refines0",
 			"http://my.url/#property1": map[string]interface{}{

--- a/pkg/parser/epub/parser_packagedoc.go
+++ b/pkg/parser/epub/parser_packagedoc.go
@@ -12,6 +12,7 @@ import (
 type PackageDocument struct {
 	Path               string
 	EPUBVersion        float64
+	EPUBVersionString  string
 	uniqueIdentifierID string
 	metadata           EPUBMetadata
 	Manifest           []Item
@@ -33,14 +34,13 @@ func ParsePackageDocument(document *xmlquery.Node, filePath string) (*PackageDoc
 	}
 
 	// Version
-	epubVersion := 1.2
-	rv := pkg.SelectAttr("version")
-	if rv != "" {
-		ev, err := strconv.ParseFloat(rv, 64)
-		if err != nil {
-			return nil, errors.Wrap(err, "failed parsing package version")
-		}
-		epubVersion = ev
+	epubVersionString := pkg.SelectAttr("version")
+	if epubVersionString == "" {
+		epubVersionString = "1.2"
+	}
+	epubVersion, err := strconv.ParseFloat(epubVersionString, 64)
+	if err != nil {
+		return nil, errors.Wrap(err, "failed parsing package version")
 	}
 
 	metadata := NewMetadataParser(epubVersion, prefixMap).Parse(document, filePath)
@@ -70,6 +70,7 @@ func ParsePackageDocument(document *xmlquery.Node, filePath string) (*PackageDoc
 	return &PackageDocument{
 		Path:               filePath,
 		EPUBVersion:        epubVersion,
+		EPUBVersionString:  epubVersionString,
 		uniqueIdentifierID: pkg.SelectAttr("unique-identifier"),
 		metadata:           *metadata,
 		Manifest:           manifest,


### PR DESCRIPTION
Add a new metadata extension `http://www.idpf.org/2007/opf#version` to store the EPUB package version in the manifest.