### PR TITLE
Use the default Meta vocabulary for unqualified metadata

### DIFF
--- a/pkg/parser/epub/metadata.go
+++ b/pkg/parser/epub/metadata.go
@@ -196,7 +196,7 @@ func (m MetadataParser) parseMetaElement(element *xmlquery.Node) *MetadataItem {
 		if content == "" {
 			return nil
 		}
-		resolvedName := resolveProperty(name, m.prefixMap, NoVocab)
+		resolvedName := resolveProperty(name, m.prefixMap, DefaultVocabMeta)
 		return &MetadataItem{
 			property: resolvedName,
 			value:    content,
@@ -214,7 +214,7 @@ func (m MetadataParser) parseMetaElement(element *xmlquery.Node) *MetadataItem {
 		}
 		resolvedScheme := strings.TrimSpace(element.SelectAttr("scheme"))
 		if resolvedScheme != "" {
-			resolvedScheme = resolveProperty(resolvedScheme, m.prefixMap, NoVocab)
+			resolvedScheme = resolveProperty(resolvedScheme, m.prefixMap, DefaultVocabMeta)
 		}
 		return &MetadataItem{
 			property: resolveProperty(propName, m.prefixMap, DefaultVocabMeta),
@@ -557,7 +557,7 @@ func (m PubMetadataAdapter) Description() string {
 }
 
 func (m PubMetadataAdapter) Cover() string {
-	return m.FirstValue("cover")
+	return m.FirstValue(VocabularyMeta + "cover")
 }
 
 func (m *PubMetadataAdapter) seedTitleData() {
@@ -1001,6 +1001,8 @@ func (m *PubMetadataAdapter) Presentation() manifest.Presentation {
 func (m *PubMetadataAdapter) OtherMetadata() map[string]interface{} {
 	if m._otherMetadata == nil {
 		usedProperties := map[string]struct{}{
+			VocabularyMeta + "cover": {}, // EPUB 2 cover meta
+
 			VocabularyDCTerms + "identifier":    {},
 			VocabularyDCTerms + "language":      {},
 			VocabularyDCTerms + "title":         {},

--- a/pkg/parser/epub/property_data_type.go
+++ b/pkg/parser/epub/property_data_type.go
@@ -24,8 +24,7 @@ var ContentReservedPrefixes = map[string]string{
 type DefaultVocab int
 
 const (
-	NoVocab DefaultVocab = iota
-	DefaultVocabMeta
+	DefaultVocabMeta = iota
 	DefaultVocabLink
 	DefaultVocabItem
 	DefaultVocabItemref
@@ -48,7 +47,7 @@ func resolveProperty(property string, prefixMap map[string]string, defaultVocab 
 			s = append(s, v)
 		}
 	}
-	if len(s) == 1 && defaultVocab != 0 {
+	if len(s) == 1 {
 		return DefaultVocabMap[defaultVocab] + s[0]
 	} else {
 		pmm, ok := prefixMap[s[0]]


### PR DESCRIPTION
When an EPUB (2 or 3) used an EPUB 2 meta property, it was added to the `OtherMetadata` map without a vocabulary, which was then expanded in the RWPM.

```xml
<meta content="1.9.20" name="Sigil version"/>
```

```json
"metadata": {
    "title": "Alice in wonderland",
    "Sigil version": "1.9.20"
}
```

To clean that up, I prefixed unqualified properties with the Meta Properties vocabulary.

> The [Meta Properties Vocabulary](https://www.w3.org/TR/epub/#app-meta-property-vocab) is the [default vocabulary](https://www.w3.org/TR/epub/#sec-default-vocab) for use with the property attribute.
> https://www.w3.org/TR/epub/#sec-meta-elem

```json
"metadata": {
    "title": "Alice in wonderland",
    "http://idpf.org/epub/vocab/package/meta/#Sigil version": "1.9.20"
}
```
It's not perfect as it's supposed to be for EPUB 3, but that gives a way for users to query unqualified metadata no matter what the source EPUB version is.