### PR TITLE
Fix computing the positions list of an FXL EPUB

### DIFF
--- a/pkg/manifest/presentation.go
+++ b/pkg/manifest/presentation.go
@@ -153,9 +153,12 @@ func (p Presentation) MarshalJSON() ([]byte, error) {
 }
 
 // Get the layout of the given resource in this publication. Falls back on REFLOWABLE.
-func LayoutOf(link Link) EPUBLayout {
+func (p Presentation) LayoutOf(link Link) EPUBLayout {
 	if l := link.Properties.Layout(); l != "" {
 		return l
+	}
+	if p.Layout != nil && *p.Layout != "" {
+		return *p.Layout
 	}
 	return EPUBLayoutReflowable
 }

--- a/pkg/parser/epub/positions_service.go
+++ b/pkg/parser/epub/positions_service.go
@@ -57,7 +57,7 @@ func (s *PositionsService) computePositions() [][]manifest.Locator {
 	positions := make([][]manifest.Locator, len(s.readingOrder))
 	for i, link := range s.readingOrder {
 		var lpositions []manifest.Locator
-		if manifest.LayoutOf(link) == manifest.EPUBLayoutFixed {
+		if s.presentation.LayoutOf(link) == manifest.EPUBLayoutFixed {
 			lpositions = s.createFixed(link, lastPositionOfPreviousResource)
 		} else {
 			lpositions = s.createReflowable(link, lastPositionOfPreviousResource, s.fetcher)


### PR DESCRIPTION
There was an issue when computing the EPUB positions list if a reading order item didn't have the `layout` link property. Instead of using the publication `metadata.presentation.layout` property, the fallback was `reflowable`.