### PR TITLE
Split or merge inferred accessibility metadata

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,10 +32,16 @@ Examples:
 
 #### Accessibility inference
 
-`rwp manifest` can infer additional accessibility metadata when they are missing, with the `--infer-a11y` flag.
+`rwp manifest` can infer additional accessibility metadata when they are missing, with the `--infer-a11y` flag. It takes one of the following arguments:
+
+| Option           | Description                                                                                            |
+|------------------|--------------------------------------------------------------------------------------------------------|
+| `no` (*default*) | No accessibility metadata will be inferred.                                                            |
+| `merged`         | Accessibility metadata will be inferred and merged with the authored ones in `metadata.accessibility`. |
+| `split`          | Accessibility metadata will be inferred but stored separately in `metadata.inferredAccessibility`.     |
 
 ```sh
-rwp manifest --infer-a11y publication.epub  | jq .metadata.accessibility
+rwp manifest --infer-a11y=merged publication.epub  | jq .metadata
 ```
 
 ##### Inferred metadata

--- a/cmd/rwp/cmd/manifest.go
+++ b/cmd/rwp/cmd/manifest.go
@@ -15,7 +15,7 @@ import (
 var indentFlag string
 
 // Infer accessibility metadata.
-var inferA11yFlag InferA11yMetadata = "no"
+var inferA11yFlag InferA11yMetadata
 
 // Infer the number of pages from the generated position list.
 var inferPageCountFlag bool
@@ -77,7 +77,7 @@ Examples:
 func init() {
 	rootCmd.AddCommand(manifestCmd)
 	manifestCmd.Flags().StringVarP(&indentFlag, "indent", "i", "", "Indentation used to pretty-print")
-	manifestCmd.Flags().Var(&inferA11yFlag, "infer-a11y", "Infer accessibility metadata (no, merged, split)")
+	manifestCmd.Flags().Var(&inferA11yFlag, "infer-a11y", "Infer accessibility metadata: no, merged, split")
 	manifestCmd.Flags().BoolVar(&inferPageCountFlag, "infer-page-count", false, "Infer the number of pages from the generated position list.")
 }
 
@@ -85,20 +85,34 @@ type InferA11yMetadata streamer.InferA11yMetadata
 
 // String is used both by fmt.Print and by Cobra in help text
 func (e *InferA11yMetadata) String() string {
-	return string(*e)
+	if e == nil {
+		return "no"
+	}
+	switch *e {
+	case InferA11yMetadata(streamer.InferA11yMetadataMerged):
+		return "merged"
+	case InferA11yMetadata(streamer.InferA11yMetadataSplit):
+		return "split"
+	default:
+		return "no"
+	}
 }
 
 func (e *InferA11yMetadata) Set(v string) error {
 	switch v {
-	case "no", "merged", "split":
-		*e = InferA11yMetadata(v)
-		return nil
+	case "no":
+		*e = InferA11yMetadata(streamer.InferA11yMetadataNo)
+	case "merged":
+		*e = InferA11yMetadata(streamer.InferA11yMetadataMerged)
+	case "split":
+		*e = InferA11yMetadata(streamer.InferA11yMetadataSplit)
 	default:
 		return errors.New(`must be one of "no", "merged", or "split"`)
 	}
+	return nil
 }
 
 // Type is only used in help text.
 func (e *InferA11yMetadata) Type() string {
-	return "InferA11yMetadata"
+	return "string"
 }

--- a/cmd/rwp/cmd/manifest.go
+++ b/cmd/rwp/cmd/manifest.go
@@ -15,7 +15,7 @@ import (
 var indentFlag string
 
 // Infer accessibility metadata.
-var inferA11yFlag bool
+var inferA11yFlag InferA11yMetadata = "no"
 
 // Infer the number of pages from the generated position list.
 var inferPageCountFlag bool
@@ -50,7 +50,7 @@ Examples:
 	RunE: func(cmd *cobra.Command, args []string) error {
 		path := filepath.Clean(args[0])
 		pub, err := streamer.New(streamer.Config{
-			InferA11yMetadata: inferA11yFlag,
+			InferA11yMetadata: streamer.InferA11yMetadata(inferA11yFlag),
 			InferPageCount:    inferPageCountFlag,
 		}).Open(
 			asset.File(path), "",
@@ -77,6 +77,28 @@ Examples:
 func init() {
 	rootCmd.AddCommand(manifestCmd)
 	manifestCmd.Flags().StringVarP(&indentFlag, "indent", "i", "", "Indentation used to pretty-print")
-	manifestCmd.Flags().BoolVar(&inferA11yFlag, "infer-a11y", false, "Infer accessibility metadata")
+	manifestCmd.Flags().Var(&inferA11yFlag, "infer-a11y", "Infer accessibility metadata (no, merged, split)")
 	manifestCmd.Flags().BoolVar(&inferPageCountFlag, "infer-page-count", false, "Infer the number of pages from the generated position list.")
+}
+
+type InferA11yMetadata streamer.InferA11yMetadata
+
+// String is used both by fmt.Print and by Cobra in help text
+func (e *InferA11yMetadata) String() string {
+	return string(*e)
+}
+
+func (e *InferA11yMetadata) Set(v string) error {
+	switch v {
+	case "no", "merged", "split":
+		*e = InferA11yMetadata(v)
+		return nil
+	default:
+		return errors.New(`must be one of "no", "merged", or "split"`)
+	}
+}
+
+// Type is only used in help text.
+func (e *InferA11yMetadata) Type() string {
+	return "InferA11yMetadata"
 }

--- a/pkg/internal/extensions/generics.go
+++ b/pkg/internal/extensions/generics.go
@@ -3,3 +3,47 @@ package extensions
 func Pointer[T any](val T) *T {
 	return &val
 }
+
+func Contains[T comparable](slice []T, element T) bool {
+	for _, v := range slice {
+		if v == element {
+			return true
+		}
+	}
+	return false
+}
+
+func Equal[T comparable](a, b []T) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i, v := range a {
+		if v != b[i] {
+			return false
+		}
+	}
+	return true
+}
+
+func AppendIfMissing[T comparable](slice []T, elems ...T) []T {
+	for _, elem := range elems {
+		slice = AppendElementIfMissing(slice, elem)
+	}
+	return slice
+}
+
+func AppendElementIfMissing[T comparable](slice []T, elem T) []T {
+	for _, v := range slice {
+		if v == elem {
+			return slice
+		}
+	}
+	return append(slice, elem)
+}
+
+func AddToSet(s []string, e string) []string {
+	if !Contains(s, e) {
+		s = append(s, e)
+	}
+	return s
+}

--- a/pkg/internal/extensions/string.go
+++ b/pkg/internal/extensions/string.go
@@ -59,19 +59,3 @@ func ParseDate(raw string) *time.Time {
 	}
 	return &t
 }
-
-func Contains[T comparable](list []T, element T) bool {
-	for _, v := range list {
-		if v == element {
-			return true
-		}
-	}
-	return false
-}
-
-func AddToSet(s []string, e string) []string {
-	if !Contains(s, e) {
-		s = append(s, e)
-	}
-	return s
-}

--- a/pkg/internal/util/map.go
+++ b/pkg/internal/util/map.go
@@ -1,0 +1,6 @@
+package util
+
+type JSONMappable interface {
+	// JSONMap returns a JSON object representation of the receiver.
+	JSONMap() (map[string]interface{}, error)
+}

--- a/pkg/manifest/metadata.go
+++ b/pkg/manifest/metadata.go
@@ -112,6 +112,34 @@ func (m Metadata) EffectiveReadingProgression() ReadingProgression {
 	return LTR
 }
 
+// InferredAccessibility returns the accessibility metadata inferred from the
+// manifest and stored in OtherMetadata.
+func (m Metadata) InferredAccessibility() *A11y {
+	var a11y *A11y
+	if a11yJSON, ok := m.OtherMetadata["inferredAccessibility"].(map[string]interface{}); ok {
+		a11y, _ = A11yFromJSON(a11yJSON)
+	}
+	return a11y
+}
+
+// SetOtherMetadata marshalls the value to a JSON map before storing it in
+// OtherMetadata under the given key.
+func (m Metadata) SetOtherMetadata(key string, value interface{}) error {
+	bytes, err := json.Marshal(value)
+	if err != nil {
+		return err
+	}
+	var object map[string]interface{}
+	err = json.Unmarshal(bytes, &object)
+	if err != nil {
+		return err
+	}
+
+	m.OtherMetadata[key] = object
+
+	return nil
+}
+
 func MetadataFromJSON(rawJson map[string]interface{}, normalizeHref LinkHrefNormalizer) (*Metadata, error) {
 	if rawJson == nil {
 		return nil, nil

--- a/pkg/manifest/metadata.go
+++ b/pkg/manifest/metadata.go
@@ -112,11 +112,13 @@ func (m Metadata) EffectiveReadingProgression() ReadingProgression {
 	return LTR
 }
 
+const InferredAccessibilityMetadataKey = "https://readium.org/webpub-manifest#inferredAccessibility"
+
 // InferredAccessibility returns the accessibility metadata inferred from the
 // manifest and stored in OtherMetadata.
 func (m Metadata) InferredAccessibility() *A11y {
 	var a11y *A11y
-	if a11yJSON, ok := m.OtherMetadata["inferredAccessibility"].(map[string]interface{}); ok {
+	if a11yJSON, ok := m.OtherMetadata[InferredAccessibilityMetadataKey].(map[string]interface{}); ok {
 		a11y, _ = A11yFromJSON(a11yJSON)
 	}
 	return a11y

--- a/pkg/streamer/a11y_infer_test.go
+++ b/pkg/streamer/a11y_infer_test.go
@@ -8,7 +8,7 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func TestReturnsAugmentedA11yMetadataWithInference(t *testing.T) {
+func TestReturnsAdditionalInferredA11yMetadata(t *testing.T) {
 	a11y := manifest.NewA11y()
 	a11y.ConformsTo = []manifest.A11yProfile{"unknown"}
 
@@ -21,7 +21,7 @@ func TestReturnsAugmentedA11yMetadataWithInference(t *testing.T) {
 		},
 	}
 
-	inferreddA11y := a11y
+	inferreddA11y := manifest.NewA11y()
 	inferreddA11y.AccessModesSufficient = [][]manifest.A11yPrimaryAccessMode{{manifest.A11yPrimaryAccessModeTextual}}
 
 	res := inferA11yMetadataFromManifest(m)
@@ -109,8 +109,9 @@ func TestInferTextualAccessModeSufficientFromLackOfMedia(t *testing.T) {
 
 	testReadingOrder := func(contains bool, mt mediatype.MediaType, extension string) {
 		testManifest(contains, manifest.Manifest{
-			Metadata:     manifest.Metadata{Accessibility: &a11y},
-			ReadingOrder: []manifest.Link{newLink(mt, extension)},
+			Metadata:        manifest.Metadata{Accessibility: &a11y},
+			ReadingOrder:    []manifest.Link{newLink(mt, extension)},
+			TableOfContents: []manifest.Link{newLink(mt, extension)},
 		})
 	}
 
@@ -122,8 +123,9 @@ func TestInferTextualAccessModeSufficientFromLackOfMedia(t *testing.T) {
 
 	testResources := func(contains bool, mt mediatype.MediaType, extension string) {
 		testManifest(contains, manifest.Manifest{
-			Metadata:  manifest.Metadata{Accessibility: &a11y},
-			Resources: []manifest.Link{newLink(mt, extension)},
+			Metadata:        manifest.Metadata{Accessibility: &a11y},
+			Resources:       []manifest.Link{newLink(mt, extension)},
+			TableOfContents: []manifest.Link{newLink(mt, extension)},
 		})
 	}
 

--- a/pkg/streamer/streamer.go
+++ b/pkg/streamer/streamer.go
@@ -39,7 +39,7 @@ type Config struct {
 	HttpClient           *http.Client               // Service performing HTTP requests.
 }
 
-type InferA11yMetadata uint
+type InferA11yMetadata uint8
 
 const (
 	// No accessibility metadata will be infered.

--- a/pkg/streamer/streamer.go
+++ b/pkg/streamer/streamer.go
@@ -6,6 +6,7 @@ import (
 	"github.com/pkg/errors"
 	"github.com/readium/go-toolkit/pkg/archive"
 	"github.com/readium/go-toolkit/pkg/asset"
+	"github.com/readium/go-toolkit/pkg/manifest"
 	"github.com/readium/go-toolkit/pkg/parser"
 	"github.com/readium/go-toolkit/pkg/parser/epub"
 	"github.com/readium/go-toolkit/pkg/parser/pdf"
@@ -114,7 +115,7 @@ func (s Streamer) Open(a asset.PublicationAsset, credentials string) (*pub.Publi
 
 	if s.inferA11yMetadata == InferA11yMetadataMerged || s.inferA11yMetadata == InferA11yMetadataSplit {
 		if inferredA11y := inferA11yMetadataFromManifest(pub.Manifest); inferredA11y != nil {
-			pub.Manifest.Metadata.SetOtherMetadata("inferredAccessibility", inferredA11y)
+			pub.Manifest.Metadata.SetOtherMetadata(manifest.InferredAccessibilityMetadataKey, inferredA11y)
 
 			if s.inferA11yMetadata == InferA11yMetadataMerged {
 				if pub.Manifest.Metadata.Accessibility == nil {


### PR DESCRIPTION
#### Accessibility inference

`rwp manifest` can infer additional accessibility metadata when they are missing, with the `--infer-a11y` flag. It takes one of the following arguments:

| Option           | Description                                                                                            |
|------------------|--------------------------------------------------------------------------------------------------------|
| `no` (*default*) | No accessibility metadata will be inferred.                                                            |
| `merged`         | Accessibility metadata will be inferred and merged with the authored ones in `metadata.accessibility`. |
| `split`          | Accessibility metadata will be inferred but stored separately in `metadata.inferredAccessibility`.     |

```sh
rwp manifest --infer-a11y=merged publication.epub  | jq .metadata
```