### PR TITLE
Don't show CLI usage on API error

### DIFF
--- a/cmd/rwp/cmd/manifest.go
+++ b/cmd/rwp/cmd/manifest.go
@@ -48,6 +48,11 @@ Examples:
 		return nil
 	},
 	RunE: func(cmd *cobra.Command, args []string) error {
+		// By the time we reach this point, we know that the arguments were
+		// properly parsed, and we don't want to show the usage if an API error
+		// occurs.
+		cmd.SilenceUsage = true
+
 		path := filepath.Clean(args[0])
 		pub, err := streamer.New(streamer.Config{
 			InferA11yMetadata: streamer.InferA11yMetadata(inferA11yFlag),


### PR DESCRIPTION
This disables CLI usage output when an error occurs while parsing a publication (See https://github.com/spf13/cobra/issues/340).

Basically changes:

```shell
$ rwp manifest invalid.epub
Error: failed opening invalid.epub: failed parsing asset: failed loading container.xml: resource: error 404: couldn't find /META-INF/container.xml in FileFetcher paths
Usage:
  rwp manifest <pub-path> [flags]

Flags:
  -h, --help                help for manifest
  -i, --indent string       Indentation used to pretty-print
      --infer-a11y string   Infer accessibility metadata: no, merged, split (default "no")
      --infer-page-count    Infer the number of pages from the generated position list.
```

to just:

```shell
$ rwp manifest invalid.epub
Error: failed opening invalid.epub: failed parsing asset: failed loading container.xml: resource: error 404: couldn't find /META-INF/container.xml in FileFetcher paths
```