### PR TITLE
Add new a11y metadata inference rules

### DIFF
--- a/pkg/manifest/link.go
+++ b/pkg/manifest/link.go
@@ -296,6 +296,18 @@ func (ll LinkList) AllAreVideo() bool {
 	return true
 }
 
+// Returns whether all the resources in the collection are bitmaps or video clips.
+func (ll LinkList) AllAreVisual() bool {
+	for _, link := range ll {
+		mt := link.MediaType()
+		if !mt.IsBitmap() && !mt.IsVideo() {
+			return false
+		}
+		// TODO should we check alternates?
+	}
+	return true
+}
+
 // Returns whether all the resources in the collection are HTML documents.
 func (ll LinkList) AllAreHTML() bool {
 	for _, link := range ll {

--- a/pkg/streamer/a11y_infer.go
+++ b/pkg/streamer/a11y_infer.go
@@ -16,6 +16,18 @@ func inferA11yMetadataFromManifest(mf manifest.Manifest) *manifest.A11y {
 		manifestA11y = manifest.NewA11y()
 	}
 
+	conformsToWCAGA := false
+	conformsToWCAGAA := false
+	for _, profile := range manifestA11y.ConformsTo {
+		if profile == manifest.EPUBA11y10WCAG20A {
+			conformsToWCAGA = true
+		}
+		if profile == manifest.EPUBA11y10WCAG20AA || profile == manifest.EPUBA11y10WCAG20AAA {
+			conformsToWCAGA = true
+			conformsToWCAGAA = true
+		}
+	}
+
 	addFeature := func(f manifest.A11yFeature) {
 		if !extensions.Contains(inferredA11y.Features, f) && !extensions.Contains(manifestA11y.Features, f) {
 			inferredA11y.Features = append(inferredA11y.Features, f)
@@ -24,7 +36,35 @@ func inferA11yMetadataFromManifest(mf manifest.Manifest) *manifest.A11y {
 
 	allResources := append(mf.ReadingOrder, mf.Resources...)
 
+	// Inferred textual if the publication is partially or fully accessible
+	// (WCAG A or above).
+	isTextual := conformsToWCAGA
+	if !isTextual {
+		// ... or if the publication does not contain any image, audio or video
+		// resource (inspect "resources" and "readingOrder" in RWPM), or if the
+		// only image available can be identified as a cover.
+		isTextual = true
+		for _, link := range allResources {
+			mt := link.MediaType()
+			if mt.IsAudio() ||
+				mt.IsVideo() ||
+				(mt.IsBitmap() && !extensions.Contains(link.Rels, "cover")) ||
+				mt.Matches(&mediatype.PDF) {
+
+				isTextual = false
+				break
+			}
+		}
+	}
+
 	if len(manifestA11y.AccessModes) == 0 {
+		if isTextual {
+			inferredA11y.AccessModes = append(inferredA11y.AccessModes, manifest.A11yAccessModeTextual)
+		}
+
+		// Inferred auditory if the publication contains a reference to an
+		// audio or video resource (inspect "resources" and "readingOrder" in
+		// RWPM).
 		for _, link := range allResources {
 			if link.MediaType().IsAudio() || link.MediaType().IsVideo() {
 				inferredA11y.AccessModes = append(inferredA11y.AccessModes, manifest.A11yAccessModeAuditory)
@@ -32,6 +72,9 @@ func inferA11yMetadataFromManifest(mf manifest.Manifest) *manifest.A11y {
 			}
 		}
 
+		// Inferred visual if the publications contain a reference to an image
+		// or a video resource (inspect "resources" and "readingOrder" in
+		// RWPM).
 		for _, link := range allResources {
 			if link.MediaType().IsBitmap() || link.MediaType().IsVideo() {
 				inferredA11y.AccessModes = append(inferredA11y.AccessModes, manifest.A11yAccessModeVisual)
@@ -42,35 +85,19 @@ func inferA11yMetadataFromManifest(mf manifest.Manifest) *manifest.A11y {
 
 	if len(manifestA11y.AccessModesSufficient) == 0 {
 		var accessMode manifest.A11yPrimaryAccessMode
-
-		for _, profile := range manifestA11y.ConformsTo {
-			if profile == manifest.EPUBA11y10WCAG20A ||
-				profile == manifest.EPUBA11y10WCAG20AA ||
-				profile == manifest.EPUBA11y10WCAG20AAA {
-				accessMode = manifest.A11yPrimaryAccessModeTextual
-				break
-			}
-		}
-
-		if accessMode == "" {
+		if isTextual {
 			accessMode = manifest.A11yPrimaryAccessModeTextual
-			for _, link := range allResources {
-				mt := link.MediaType()
-				if mt.IsAudio() ||
-					mt.IsVideo() ||
-					(mt.IsBitmap() && !extensions.Contains(link.Rels, "cover")) ||
-					mt.Matches(&mediatype.PDF) {
-
-					accessMode = ""
-					break
-				}
-			}
 		}
 
 		if accessMode == "" {
 			if allResources.AllAreAudio() {
+				// Inferred auditory if all references in the "readingOrder" are
+				// identified as audio resources.
 				accessMode = manifest.A11yPrimaryAccessModeAuditory
+
 			} else if allResources.AllAreVisual() {
+				// Inferred visual if all references in the "readingOrder" are
+				// identified as images or video resources.
 				accessMode = manifest.A11yPrimaryAccessModeVisual
 			}
 		}
@@ -99,11 +126,8 @@ func inferA11yMetadataFromManifest(mf manifest.Manifest) *manifest.A11y {
 			}
 		}
 
-		if mf.Metadata.Presentation != nil && *mf.Metadata.Presentation.Layout == manifest.EPUBLayoutReflowable {
-			if extensions.Contains(manifestA11y.ConformsTo, manifest.EPUBA11y10WCAG20AA) ||
-				extensions.Contains(manifestA11y.ConformsTo, manifest.EPUBA11y10WCAG20AAA) {
-				addFeature(manifest.A11yFeatureDisplayTransformability)
-			}
+		if mf.Metadata.Presentation != nil && *mf.Metadata.Presentation.Layout == manifest.EPUBLayoutReflowable && conformsToWCAGAA {
+			addFeature(manifest.A11yFeatureDisplayTransformability)
 		}
 	}
 

--- a/pkg/streamer/a11y_infer.go
+++ b/pkg/streamer/a11y_infer.go
@@ -126,6 +126,13 @@ func inferA11yMetadataFromManifest(mf manifest.Manifest) *manifest.A11y {
 			}
 		}
 
+		for _, link := range mf.Resources {
+			if link.MediaType().Matches(&mediatype.SMIL) {
+				addFeature(manifest.A11yFeatureSynchronizedAudioText)
+				break
+			}
+		}
+
 		if mf.Metadata.Presentation != nil && *mf.Metadata.Presentation.Layout == manifest.EPUBLayoutReflowable && conformsToWCAGAA {
 			addFeature(manifest.A11yFeatureDisplayTransformability)
 		}

--- a/pkg/streamer/a11y_infer_test.go
+++ b/pkg/streamer/a11y_infer_test.go
@@ -313,17 +313,16 @@ func TestInferFeatureDisplayTransformability(t *testing.T) {
 
 // If the publication contains any reference to Media Overlays.
 func TestInferFeatureSynchronizedAudioText(t *testing.T) {
-	link := newLink(mediatype.HTML, "html")
-	link.Properties = map[string]interface{}{
-		"contains": []string{"mathml"},
-	}
+	link := newLink(mediatype.XHTML, "xhtml")
+	smil := newLink(mediatype.SMIL, "smil")
 	m := manifest.Manifest{
 		Metadata: manifest.Metadata{
 			ConformsTo: []manifest.Profile{manifest.ProfileEPUB},
 		},
 		ReadingOrder: []manifest.Link{link},
+		Resources:    []manifest.Link{smil},
 	}
-	assertFeature(t, m, manifest.A11yFeatureMathML)
+	assertFeature(t, m, manifest.A11yFeatureSynchronizedAudioText)
 }
 
 func assertFeature(t *testing.T, m manifest.Manifest, feature manifest.A11yFeature) {


### PR DESCRIPTION
* Infer `visual` `accessModeSufficient` for publications containing only image or video resources.
* Infer `textual` `accessMode` with publications conforming to WCAG A, or referencing no media resources.
* Infer `synchronizedAudioText` feature when a publication references SMIL resources.