### PR TITLE
Fix `textual` access mode inference with FXL

### DIFF
--- a/pkg/parser/epub/factory.go
+++ b/pkg/parser/epub/factory.go
@@ -73,10 +73,9 @@ func (f PublicationFactory) Create() manifest.Manifest {
 			readingOrder = append(readingOrder, f.computeLink(item, []string{}))
 		}
 	}
-	readingOrderAllIds := f.computeIdsWithFallbacks(readingOrderIds)
 	var resourceItems []Item
 	for _, item := range mani {
-		if !extensions.Contains(readingOrderAllIds, item.ID) {
+		if !extensions.Contains(readingOrderIds, item.ID) {
 			resourceItems = append(resourceItems, item)
 		}
 	}
@@ -142,40 +141,6 @@ func mapEPUBLink(link EPUBLink) manifest.Link {
 	}
 
 	return l
-}
-
-// Recursively find the ids of the fallback items in [items]
-func (f PublicationFactory) computeIdsWithFallbacks(ids []string) []string {
-	var fallbackIds []string
-	for _, id := range ids {
-		for _, v := range f.computeFallbackChain(id) {
-			if !extensions.Contains(fallbackIds, v) {
-				fallbackIds = append(fallbackIds, v)
-			}
-		}
-	}
-	return fallbackIds
-}
-
-// Compute the ids contained in the fallback chain of [item]
-func (f PublicationFactory) computeFallbackChain(id string) []string {
-	// The termination has already been checked while computing links
-	var ids []string
-	item, ok := f.itemById[id]
-	if !ok {
-		return ids
-	}
-	if item.ID != "" {
-		ids = append(ids, item.ID)
-	}
-	if item.fallback != "" {
-		for _, v := range f.computeFallbackChain(item.fallback) {
-			if !extensions.Contains(ids, v) {
-				ids = append(ids, v)
-			}
-		}
-	}
-	return ids
 }
 
 // Compute a Publication [Link] for an epub [Item] and its fallbacks

--- a/pkg/streamer/a11y_infer.go
+++ b/pkg/streamer/a11y_infer.go
@@ -39,10 +39,14 @@ func inferA11yMetadataFromManifest(mf manifest.Manifest) *manifest.A11y {
 	// Inferred textual if the publication is partially or fully accessible
 	// (WCAG A or above).
 	isTextual := conformsToWCAGA
-	if !isTextual {
-		// ... or if the publication does not contain any image, audio or video
-		// resource (inspect "resources" and "readingOrder" in RWPM), or if the
-		// only image available can be identified as a cover.
+
+	// ... or if a reflowable EPUB does not contain any image, audio or
+	// video resource (inspect "resources" and "readingOrder" in RWPM), or
+	// if the only image available can be identified as a cover.
+	if !isTextual &&
+		mf.ConformsTo(manifest.ProfileEPUB) &&
+		mf.Metadata.Presentation != nil &&
+		*mf.Metadata.Presentation.Layout == manifest.EPUBLayoutReflowable {
 		isTextual = true
 		for _, link := range allResources {
 			mt := link.MediaType()


### PR DESCRIPTION
* We can't really infer a `textual` access mode with a FXL EPUB, even if it doesn't contain any image, because the DOM itself might be garbled (e.g. absolute positioning of letters/words). The inference was updated to only check reflowable EPUBs.
* EPUB manifest items that are fallbacks of a spine item are now also added to the `resources` list in the RWPM. Often, these resources are actually embedded in the main XHTML resource. Not having them in `resources` produced false positives in the a11y inference as the bitmaps in `Link.children` were not taken into account.