### PR TITLE
Add safety check for invalid font obfuscation key

### DIFF
--- a/pkg/parser/epub/deobfuscator.go
+++ b/pkg/parser/epub/deobfuscator.go
@@ -119,6 +119,12 @@ func (d DeobfuscatingResource) Stream(w io.Writer, start int64, end int64) (int6
 			shasum := sha1.Sum([]byte(d.identifier))
 			obfuscationKey = shasum[:]
 		}
+
+		// If getHashKeyAdobe() is blank, meaning the hex decoding of the UUID failed
+		if len(obfuscationKey) == 0 {
+			return 0, fetcher.Other(errors.New("error deriving font deobfuscation key"))
+		}
+
 		deobfuscateFont(obfuscatedPortion, start, obfuscationKey, v)
 
 		defer pr.Close()


### PR DESCRIPTION
Some broken publications have an invalid font obfuscation key, and this causes a panic due to a divide by zero in the `deobfuscateFont` function. This adds a check for that