### PR TITLE
Change toolkit version key

### DIFF
--- a/pkg/manifest/metadata.go
+++ b/pkg/manifest/metadata.go
@@ -462,7 +462,7 @@ func (m *Metadata) UnmarshalJSON(b []byte) error {
 }
 
 // If you really don't want the version info in your manifest, you can blank this value.
-var ToolkitVersionKey = "https://github.com/readium/go-toolkit/releases"
+var ToolkitVersionKey = "https://github.com/readium/go-toolkit#version"
 
 func (m Metadata) MarshalJSON() ([]byte, error) {
 	j := make(map[string]interface{})


### PR DESCRIPTION
Now that we not longer make full releases on GitHub for the go-toolkit, it's confusing to have `https://github.com/readium/go-toolkit/releases` as the JSON key for the toolkit version in manifests. The new value is `https://github.com/readium/go-toolkit#version`