### PR TITLE
Fix typo in `describedMath` a11y feature

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 
 **Warning:** Features marked as *alpha* may change or be removed in a future release without notice. Use with caution.
 
+## Unreleased
+
+### Fixed
+
+- Fixed a typo in the accessibility metadata (`describeMath` should be `describedMath`).
+
 ## [0.13.1] - 2025-12-08
 
 ### Changed

--- a/pkg/manifest/a11y.go
+++ b/pkg/manifest/a11y.go
@@ -379,7 +379,7 @@ const (
 
 	// Textual descriptions of math equations are included, whether in the alt attribute
 	// for image-based equations,
-	A11yFeatureDescribedMath A11yFeature = "describeMath"
+	A11yFeatureDescribedMath A11yFeature = "describedMath"
 
 	// Descriptions are provided for image-based visual content and/or complex structures
 	// such as tables, mathematics, diagrams, and charts.


### PR DESCRIPTION
## Fixed

- Fixed a typo in the accessibility metadata (`describeMath` should be `describedMath`).

Source: https://www.w3.org/community/reports/a11y-discov-vocab/CG-FINAL-vocabulary-20241209/#describedMath