### PR TITLE
Use functions from `require`

### DIFF
--- a/pkg/fetcher/fetcher_archive_test.go
+++ b/pkg/fetcher/fetcher_archive_test.go
@@ -7,11 +7,12 @@ import (
 	"github.com/readium/go-toolkit/pkg/manifest"
 	"github.com/readium/go-toolkit/pkg/mediatype"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func withArchiveFetcher(t *testing.T, callback func(a *ArchiveFetcher)) {
 	a, err := NewArchiveFetcherFromPath(t.Context(), "./testdata/epub.epub")
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	callback(a)
 }
 
@@ -55,7 +56,7 @@ func TestArchiveFetcherLinks(t *testing.T) {
 
 	withArchiveFetcher(t, func(a *ArchiveFetcher) {
 		links, err := a.Links(t.Context())
-		assert.Nil(t, err)
+		require.Nil(t, err)
 
 		mustLinks := make([]manifest.Link, len(mustContain))
 		for i, l := range mustContain {
@@ -88,15 +89,13 @@ func TestArchiveFetcherRead(t *testing.T) {
 	withArchiveFetcher(t, func(a *ArchiveFetcher) {
 		resource := a.Get(t.Context(), manifest.Link{Href: manifest.MustNewHREFFromString("mimetype", false)})
 		bin, err := resource.Read(t.Context(), 0, 0)
-		if assert.Nil(t, err) {
-			assert.Equal(t, "application/epub+zip", string(bin))
-		}
+		require.Nil(t, err)
+		assert.Equal(t, "application/epub+zip", string(bin))
 		var b bytes.Buffer
 		n, err := resource.Stream(t.Context(), &b, 0, 0)
-		if assert.Nil(t, err) {
-			assert.EqualValues(t, 20, n)
-			assert.Equal(t, "application/epub+zip", b.String())
-		}
+		require.Nil(t, err)
+		assert.EqualValues(t, 20, n)
+		assert.Equal(t, "application/epub+zip", b.String())
 	})
 }
 
@@ -104,15 +103,13 @@ func TestArchiveFetcherReadRange(t *testing.T) {
 	withArchiveFetcher(t, func(a *ArchiveFetcher) {
 		resource := a.Get(t.Context(), manifest.Link{Href: manifest.MustNewHREFFromString("mimetype", false)})
 		bin, err := resource.Read(t.Context(), 0, 10)
-		if assert.Nil(t, err) {
-			assert.Equal(t, "application", string(bin))
-		}
+		require.Nil(t, err)
+		assert.Equal(t, "application", string(bin))
 		var b bytes.Buffer
 		n, err := resource.Stream(t.Context(), &b, 0, 10)
-		if assert.Nil(t, err) {
-			assert.EqualValues(t, 11, n)
-			assert.Equal(t, "application", b.String())
-		}
+		require.Nil(t, err)
+		assert.EqualValues(t, 11, n)
+		assert.Equal(t, "application", b.String())
 	})
 }
 
@@ -120,7 +117,7 @@ func TestArchiveFetcherComputingLength(t *testing.T) {
 	withArchiveFetcher(t, func(a *ArchiveFetcher) {
 		resource := a.Get(t.Context(), manifest.Link{Href: manifest.MustNewHREFFromString("mimetype", false)})
 		length, err := resource.Length(t.Context())
-		assert.Nil(t, err)
+		require.Nil(t, err)
 		assert.EqualValues(t, 20, length)
 	})
 }

--- a/pkg/fetcher/fetcher_file_test.go
+++ b/pkg/fetcher/fetcher_file_test.go
@@ -7,6 +7,7 @@ import (
 	"github.com/readium/go-toolkit/pkg/manifest"
 	"github.com/readium/go-toolkit/pkg/mediatype"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 var testFileFetcher = &FileFetcher{
@@ -33,42 +34,37 @@ func TestFileFetcherReadNotFound(t *testing.T) {
 func TestFileFetcherHrefInMap(t *testing.T) {
 	resource := testFileFetcher.Get(t.Context(), manifest.Link{Href: manifest.MustNewHREFFromString("file_href", false)})
 	bin, err := resource.Read(t.Context(), 0, 0)
-	if assert.Nil(t, err) {
-		assert.Equal(t, "text", string(bin))
-	}
+	require.Nil(t, err)
+	assert.Equal(t, "text", string(bin))
 	var b bytes.Buffer
 	n, err := resource.Stream(t.Context(), &b, 0, 0)
-	if assert.Nil(t, err) {
-		assert.EqualValues(t, 4, n)
-		assert.Equal(t, "text", b.String())
-	}
+	require.Nil(t, err)
+	assert.EqualValues(t, 4, n)
+	assert.Equal(t, "text", b.String())
 }
 
 func TestFileFetcherDirectoryFile(t *testing.T) {
 	resource := testFileFetcher.Get(t.Context(), manifest.Link{Href: manifest.MustNewHREFFromString("dir_href/text1.txt", false)})
 	bin, err := resource.Read(t.Context(), 0, 0)
-	if assert.Nil(t, err) {
-		assert.Equal(t, "text1", string(bin))
-	}
+	require.Nil(t, err)
+	assert.Equal(t, "text1", string(bin))
 	var b bytes.Buffer
 	n, err := resource.Stream(t.Context(), &b, 0, 0)
-	if assert.Nil(t, err) {
-		assert.EqualValues(t, 5, n)
-		assert.Equal(t, "text1", b.String())
-	}
+	require.Nil(t, err)
+	assert.EqualValues(t, 5, n)
+	assert.Equal(t, "text1", b.String())
 }
 
 func TestFileFetcherSubdirectoryFile(t *testing.T) {
 	resource := testFileFetcher.Get(t.Context(), manifest.Link{Href: manifest.MustNewHREFFromString("dir_href/subdirectory/text2.txt", false)})
 	bin, err := resource.Read(t.Context(), 0, 0)
-	assert.Nil(t, err)
+	require.Nil(t, err)
 	assert.Equal(t, "text2", string(bin))
 	var b bytes.Buffer
 	n, err := resource.Stream(t.Context(), &b, 0, 0)
-	if assert.Nil(t, err) {
-		assert.EqualValues(t, 5, n)
-		assert.Equal(t, "text2", b.String())
-	}
+	require.Nil(t, err)
+	assert.EqualValues(t, 5, n)
+	assert.Equal(t, "text2", b.String())
 }
 
 func TestFileFetcherDirectoryNotFound(t *testing.T) {
@@ -90,73 +86,63 @@ func TestFileFetcherDirectoryTraversalNotFound(t *testing.T) {
 func TestFileFetcherReadRange(t *testing.T) {
 	resource := testFileFetcher.Get(t.Context(), manifest.Link{Href: manifest.MustNewHREFFromString("file_href", false)})
 	bin, err := resource.Read(t.Context(), 0, 2)
-	if assert.Nil(t, err) {
-		assert.Equal(t, "tex", string(bin), "read data should be the first three bytes of the file")
-	}
+	require.Nil(t, err)
+	assert.Equal(t, "tex", string(bin), "read data should be the first three bytes of the file")
 
 	var b bytes.Buffer
 	n, err := resource.Stream(t.Context(), &b, 0, 2)
-	if assert.Nil(t, err) {
-		assert.EqualValues(t, 3, n)
-		assert.Equal(t, "tex", b.String(), "read data should be the first three bytes of the file")
-	}
+	require.Nil(t, err)
+	assert.EqualValues(t, 3, n)
+	assert.Equal(t, "tex", b.String(), "read data should be the first three bytes of the file")
 }
 
 func TestFileFetcherTwoRangesSameResource(t *testing.T) {
 	resource := testFileFetcher.Get(t.Context(), manifest.Link{Href: manifest.MustNewHREFFromString("file_href", false)})
 	bin, err := resource.Read(t.Context(), 0, 1)
-	if assert.Nil(t, err) {
-		assert.Equal(t, "te", string(bin))
-	}
+	require.Nil(t, err)
+	assert.Equal(t, "te", string(bin))
 	var b bytes.Buffer
 	n, err := resource.Stream(t.Context(), &b, 0, 1)
-	if assert.Nil(t, err) {
-		assert.EqualValues(t, 2, n)
-		assert.Equal(t, "te", b.String())
-	}
+	require.Nil(t, err)
+	assert.EqualValues(t, 2, n)
+	assert.Equal(t, "te", b.String())
 
 	bin, err = resource.Read(t.Context(), 1, 3)
-	if assert.Nil(t, err) {
-		assert.Equal(t, "ext", string(bin))
-	}
+	require.Nil(t, err)
+	assert.Equal(t, "ext", string(bin))
 	b.Reset()
 	n, err = resource.Stream(t.Context(), &b, 1, 3)
-	if assert.Nil(t, err) {
-		assert.EqualValues(t, 3, n)
-		assert.Equal(t, "ext", b.String())
-	}
+	require.Nil(t, err)
+	assert.EqualValues(t, 3, n)
+	assert.Equal(t, "ext", b.String())
 }
 
 func TestFileFetcherOutOfRangeClamping(t *testing.T) {
 	resource := testFileFetcher.Get(t.Context(), manifest.Link{Href: manifest.MustNewHREFFromString("file_href", false)})
 	bin, err := resource.Read(t.Context(), -5, 60)
-	if assert.Nil(t, err) {
-		assert.Equal(t, "text", string(bin))
-	}
+	require.Nil(t, err)
+	assert.Equal(t, "text", string(bin))
 	var b bytes.Buffer
 	n, err := resource.Stream(t.Context(), &b, -5, 60)
-	if assert.Nil(t, err) {
-		assert.EqualValues(t, 4, n)
-		assert.Equal(t, "text", b.String())
-	}
+	require.Nil(t, err)
+	assert.EqualValues(t, 4, n)
+	assert.Equal(t, "text", b.String())
 }
 
 func TestFileFetcherDecreasingRange(t *testing.T) {
 	resource := testFileFetcher.Get(t.Context(), manifest.Link{Href: manifest.MustNewHREFFromString("file_href", false)})
 	_, err := resource.Read(t.Context(), 60, 20)
-	if assert.Error(t, err) {
-		assert.Equal(t, RangeNotSatisfiable(err.Cause), err, "range isn't satisfiable")
-	}
+	require.Error(t, err)
+	assert.Equal(t, RangeNotSatisfiable(err.Cause), err, "range isn't satisfiable")
 	_, err = resource.Stream(t.Context(), &bytes.Buffer{}, 60, 20)
-	if assert.Error(t, err) {
-		assert.Equal(t, RangeNotSatisfiable(err.Cause), err, "range isn't satisfiable")
-	}
+	require.Error(t, err)
+	assert.Equal(t, RangeNotSatisfiable(err.Cause), err, "range isn't satisfiable")
 }
 
 func TestFileFetcherComputingLength(t *testing.T) {
 	resource := testFileFetcher.Get(t.Context(), manifest.Link{Href: manifest.MustNewHREFFromString("file_href", false)})
 	length, err := resource.Length(t.Context())
-	assert.Nil(t, err)
+	require.Nil(t, err)
 	assert.EqualValues(t, 4, length)
 }
 
@@ -174,7 +160,7 @@ func TestFileFetcherFileNotFoundLength(t *testing.T) {
 
 func TestFileFetcherLinks(t *testing.T) {
 	links, err := testFileFetcher.Links(t.Context())
-	assert.Nil(t, err)
+	require.Nil(t, err)
 
 	mustContain := manifest.LinkList{{
 		Href:      manifest.MustNewHREFFromString("dir_href/subdirectory/hello.mp3", false),

--- a/pkg/internal/util/css_test.go
+++ b/pkg/internal/util/css_test.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/andybalholm/cascadia"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"golang.org/x/net/html"
 )
 
@@ -30,15 +31,11 @@ const testDoc = `<?xml version="1.0" encoding="UTF-8"?>
 
 func TestCSSSelector(t *testing.T) {
 	doc, err := html.Parse(strings.NewReader(testDoc))
-	if !assert.NoError(t, err) {
-		return
-	}
+	require.NoError(t, err)
 
 	qf := func(query string) string {
 		n := cascadia.Query(doc, cascadia.MustCompile(query))
-		if !assert.NotNil(t, n) {
-			t.FailNow()
-		}
+		require.NotNil(t, n)
 		return CSSSelector(n)
 	}
 

--- a/pkg/manifest/a11y_test.go
+++ b/pkg/manifest/a11y_test.go
@@ -5,17 +5,18 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestA11yUnmarshalMinimalJSON(t *testing.T) {
 	var m A11y
-	assert.NoError(t, json.Unmarshal([]byte("{}"), &m))
+	require.NoError(t, json.Unmarshal([]byte("{}"), &m))
 	assert.Equal(t, NewA11y(), m, "unmarshalled JSON object should be equal to A11y object")
 }
 
 func TestA11yUnmarshalFullJSON(t *testing.T) {
 	var m A11y
-	assert.NoError(t, json.Unmarshal([]byte(`{
+	require.NoError(t, json.Unmarshal([]byte(`{
 		"conformsTo": ["https://profile1", "https://profile2"],
 		"certification": {
 			"certifiedBy": "company1",
@@ -67,13 +68,13 @@ func TestA11yUnmarshalFullJSON(t *testing.T) {
 
 func TestA11yUnmarshalInvalidSummaryIsIgnored(t *testing.T) {
 	var m A11y
-	assert.NoError(t, json.Unmarshal([]byte(`{"summary": ["sum1", "sum2"]}`), &m))
+	require.NoError(t, json.Unmarshal([]byte(`{"summary": ["sum1", "sum2"]}`), &m))
 	assert.Equal(t, NewA11y(), m, "unmarshalled JSON object should be equal to A11y object")
 }
 
 func TestA11yUnmarshalConformsToString(t *testing.T) {
 	var m A11y
-	assert.NoError(t, json.Unmarshal([]byte(`{"conformsTo": "http://www.idpf.org/epub/a11y/accessibility-20170105.html#wcag-a"}`), &m))
+	require.NoError(t, json.Unmarshal([]byte(`{"conformsTo": "http://www.idpf.org/epub/a11y/accessibility-20170105.html#wcag-a"}`), &m))
 	var e A11y = NewA11y()
 	e.ConformsTo = []A11yProfile{EPUBA11y10WCAG20A}
 	assert.Equal(t, e, m, "unmarshalled JSON object should be equal to A11y object")
@@ -81,7 +82,7 @@ func TestA11yUnmarshalConformsToString(t *testing.T) {
 
 func TestA11yUnmarshalConformsToArray(t *testing.T) {
 	var m A11y
-	assert.NoError(t, json.Unmarshal([]byte(`{"conformsTo": ["http://www.idpf.org/epub/a11y/accessibility-20170105.html#wcag-a", "https://profile2"]}`), &m))
+	require.NoError(t, json.Unmarshal([]byte(`{"conformsTo": ["http://www.idpf.org/epub/a11y/accessibility-20170105.html#wcag-a", "https://profile2"]}`), &m))
 	var e A11y = NewA11y()
 	e.ConformsTo = []A11yProfile{EPUBA11y10WCAG20A, "https://profile2"}
 	assert.Equal(t, e, m, "unmarshalled JSON object should be equal to A11y object")
@@ -107,7 +108,7 @@ func TestA11ySortConformsTo(t *testing.T) {
 
 func TestA11yUnmarshalAccessModeSufficientContainingBothStringsAndArrays(t *testing.T) {
 	var m A11y
-	assert.NoError(t, json.Unmarshal([]byte(`{"accessModeSufficient": ["auditory", ["visual", "tactile"], [], "visual"]}`), &m))
+	require.NoError(t, json.Unmarshal([]byte(`{"accessModeSufficient": ["auditory", ["visual", "tactile"], [], "visual"]}`), &m))
 	var e A11y = NewA11y()
 	e.AccessModesSufficient = [][]A11yPrimaryAccessMode{
 		{A11yPrimaryAccessModeAuditory},
@@ -127,7 +128,7 @@ func TestA11yMarshalMinimalJSON(t *testing.T) {
 		Exemptions:            []A11yExemption{},
 	}
 	data, err := json.Marshal(m)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.Equal(t, data, []byte(`{}`), "unmarshalled JSON object should be equal to A11y object")
 }
 
@@ -169,7 +170,7 @@ func TestA11yMarshalFullJSON(t *testing.T) {
 		},
 	}
 	data, err := json.Marshal(m)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.Equal(
 		t,
 		data,

--- a/pkg/manifest/collection_test.go
+++ b/pkg/manifest/collection_test.go
@@ -6,11 +6,12 @@ import (
 
 	"github.com/readium/go-toolkit/pkg/util/url"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestPubCollectionUnmarshalMinimalJSON(t *testing.T) {
 	var pc PublicationCollection
-	assert.NoError(t, json.Unmarshal([]byte(`{
+	require.NoError(t, json.Unmarshal([]byte(`{
 		"metadata": null,
 		"links": [{"href": "/link"}]
 	}`), &pc))
@@ -23,7 +24,7 @@ func TestPubCollectionUnmarshalMinimalJSON(t *testing.T) {
 
 func TestPubCollectionUnmarshalFullJSON(t *testing.T) {
 	var pc PublicationCollection
-	assert.NoError(t, json.Unmarshal([]byte(`{
+	require.NoError(t, json.Unmarshal([]byte(`{
 		"metadata": {
 			"metadata1": "value"
 		},
@@ -77,13 +78,13 @@ func TestPubCollectionUnmarshalFullJSON(t *testing.T) {
 
 func TestPubCollectionUnmarshalNilJSON(t *testing.T) {
 	pc, err := PublicationCollectionFromJSON(nil)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.Nil(t, pc)
 }
 
 func TestPubCollectionUnmarshalJSONMultipleCollections(t *testing.T) {
 	var pcsr map[string]interface{}
-	assert.NoError(t, json.Unmarshal([]byte(`{
+	require.NoError(t, json.Unmarshal([]byte(`{
 		"sub1": {
 			"links": [
 				{"href": "/sublink"}
@@ -107,7 +108,7 @@ func TestPubCollectionUnmarshalJSONMultipleCollections(t *testing.T) {
 		]
 	}`), &pcsr))
 	pcs, err := PublicationCollectionsFromJSON(pcsr)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	assert.Equal(t, PublicationCollectionMap{
 		"sub1": {{
@@ -130,7 +131,7 @@ func TestPubCollectionMinimalJSON(t *testing.T) {
 		Metadata: map[string]interface{}{},
 		Links:    []Link{{Href: NewHREF(url.MustURLFromString("/link"))}},
 	})
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.JSONEq(t, `{
 		"metadata": {},
 		"links": [{"href": "/link"}]
@@ -158,7 +159,7 @@ func TestPubCollectionFullJSON(t *testing.T) {
 			},
 		},
 	})
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.JSONEq(t, `{
 		"metadata": {
 			"metadata1": "value"
@@ -211,7 +212,7 @@ func TestPubCollectionMultipleCollectionsJSON(t *testing.T) {
 			{Metadata: map[string]interface{}{}, Links: []Link{{Href: NewHREF(url.MustURLFromString("/sublink4"))}}},
 		},
 	})
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.JSONEq(t, `{
 		"sub1": {
 			"metadata": {},

--- a/pkg/manifest/contributor_test.go
+++ b/pkg/manifest/contributor_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestContributorUnmarshalJSONString(t *testing.T) {
@@ -12,7 +13,7 @@ func TestContributorUnmarshalJSONString(t *testing.T) {
 		LocalizedName: NewLocalizedStringFromString("John Smith"),
 	}
 	var c2 Contributor
-	assert.NoError(t, json.Unmarshal([]byte(`"John Smith"`), &c2))
+	require.NoError(t, json.Unmarshal([]byte(`"John Smith"`), &c2))
 	assert.Equal(t, c1, c2, "unmarshalled JSON string should be equal to string")
 }
 
@@ -21,7 +22,7 @@ func TestContributorUnmarshalMinimalJSON(t *testing.T) {
 		LocalizedName: NewLocalizedStringFromString("John Smith"),
 	}
 	var c2 Contributor
-	assert.NoError(t, json.Unmarshal([]byte(`{"name": "John Smith"}`), &c2))
+	require.NoError(t, json.Unmarshal([]byte(`{"name": "John Smith"}`), &c2))
 	assert.Equal(t, c1, c2, "unmarshalled JSON object should be equal to Contributor object")
 }
 
@@ -47,7 +48,7 @@ func TestContributorUnmarshalFullJSON(t *testing.T) {
 		},
 	}
 	var c2 Contributor
-	assert.NoError(t, json.Unmarshal([]byte(`{
+	require.NoError(t, json.Unmarshal([]byte(`{
 		"name": "Colin Greenwood",
 		"identifier": "colin",
 		"altIdentifier": [{"value": "id123", "scheme": "scheme456"}],
@@ -68,7 +69,7 @@ func TestContributorUnmarshalJSONWithDuplicateRoles(t *testing.T) {
 		Roles:         []string{"singer", "guitarist"},
 	}
 	var c2 Contributor
-	assert.NoError(t, json.Unmarshal([]byte(`{
+	require.NoError(t, json.Unmarshal([]byte(`{
 		"name": "Thom Yorke",
 		"role": ["singer", "guitarist", "guitarist"]
 	}`), &c2))
@@ -99,7 +100,7 @@ func TestContributorNameFromDefaultTranslation(t *testing.T) {
 func TestContributorMinimalJSON(t *testing.T) {
 	l := Contributor{LocalizedName: NewLocalizedStringFromString("Colin Greenwood")}
 	s, err := json.Marshal(l)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.JSONEq(t, `"Colin Greenwood"`, string(s), "JSON of Contributor with one name should be equal to JSON representation")
 }
 
@@ -109,7 +110,7 @@ func TestContributorMinimalJSONWithLocalizedName(t *testing.T) {
 	n.SetTranslation("fr", "Colain Grinwoud")
 	l := Contributor{LocalizedName: n}
 	s, err := json.Marshal(l)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.JSONEq(t, `{"name": {"fr": "Colain Grinwoud", "en": "Colin Greenwood"}}`, string(s), "JSON of Contributor with one name should be equal to JSON representation")
 }
 
@@ -135,7 +136,7 @@ func TestContributorFullJSON(t *testing.T) {
 		},
 	}
 	s, err := json.Marshal(l)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.JSONEq(t, `{
 		"name": "Colin Greenwood",
 		"identifier": "colin",

--- a/pkg/manifest/encryption_test.go
+++ b/pkg/manifest/encryption_test.go
@@ -5,11 +5,12 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestEncryptionUnmarshalMinimalJSON(t *testing.T) {
 	var m Encryption
-	assert.NoError(t, json.Unmarshal([]byte(`{"algorithm": "http://algo"}`), &m))
+	require.NoError(t, json.Unmarshal([]byte(`{"algorithm": "http://algo"}`), &m))
 	assert.Equal(
 		t,
 		Encryption{
@@ -22,7 +23,7 @@ func TestEncryptionUnmarshalMinimalJSON(t *testing.T) {
 
 func TestEncryptionUnmarshalFullJSON(t *testing.T) {
 	var m Encryption
-	assert.NoError(t, json.Unmarshal([]byte(`{
+	require.NoError(t, json.Unmarshal([]byte(`{
 		"algorithm": "http://algo",
 		"compression": "gzip",
 		"originalLength": 42099,
@@ -40,7 +41,7 @@ func TestEncryptionUnmarshalFullJSON(t *testing.T) {
 
 func TestEncryptionUnmarshalNullJSON(t *testing.T) {
 	enc, err := EncryptionFromJSON(nil)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.Nil(t, enc)
 }
 
@@ -54,7 +55,7 @@ func TestEncryptionMarshalMinimalJSON(t *testing.T) {
 		Algorithm: "http://algo",
 	}
 	data, err := json.Marshal(m)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.Equal(t, data, []byte(`{"algorithm":"http://algo"}`), "unmarshalled JSON object should be equal to Encryption object")
 }
 
@@ -67,7 +68,7 @@ func TestEncryptionMarshalFullJSON(t *testing.T) {
 		Scheme:         "http://scheme",
 	}
 	data, err := json.Marshal(m)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.Equal(
 		t,
 		data,

--- a/pkg/manifest/link_test.go
+++ b/pkg/manifest/link_test.go
@@ -7,6 +7,7 @@ import (
 	"github.com/readium/go-toolkit/pkg/mediatype"
 	"github.com/readium/go-toolkit/pkg/util/url"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 /*func TestLinkTemplateParameters(t *testing.T) {
@@ -37,14 +38,14 @@ func TestLinkTemplateExpand(t *testing.T) {
 
 func TestLinkUnmarshalMinimalJSON(t *testing.T) {
 	var l Link
-	assert.NoError(t, json.Unmarshal([]byte(`{"href": "http://href"}`), &l))
+	require.NoError(t, json.Unmarshal([]byte(`{"href": "http://href"}`), &l))
 	u, _ := url.URLFromString("http://href")
 	assert.Equal(t, Link{Href: NewHREF(u)}, l, "parsed JSON object should be equal to Link object")
 }
 
 func TestLinkUnmarshalFullJSON(t *testing.T) {
 	var l Link
-	assert.NoError(t, json.Unmarshal([]byte(`{
+	require.NoError(t, json.Unmarshal([]byte(`{
 		"href": "http://href",
 		"type": "application/pdf",
 		"templated": true,
@@ -94,31 +95,31 @@ func TestLinkUnmarshalFullJSON(t *testing.T) {
 
 func TestLinkUnmarshalNilJSON(t *testing.T) {
 	s, err := LinkFromJSON(nil)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.Nil(t, s)
 }
 
 func TestLinkUnmarshalJSONRelString(t *testing.T) {
 	var l Link
-	assert.NoError(t, json.Unmarshal([]byte(`{"href": "a", "rel": "publication"}`), &l))
+	require.NoError(t, json.Unmarshal([]byte(`{"href": "a", "rel": "publication"}`), &l))
 	assert.Equal(t, Link{Href: MustNewHREFFromString("a", false), Rels: []string{"publication"}}, l)
 }
 
 func TestLinkUnmarshalJSONTemplatedDefaultFalse(t *testing.T) {
 	var l Link
-	assert.NoError(t, json.Unmarshal([]byte(`{"href": "a"}`), &l))
+	require.NoError(t, json.Unmarshal([]byte(`{"href": "a"}`), &l))
 	assert.False(t, l.Href.IsTemplated())
 }
 
 func TestLinkUnmarshalJSONTemplatedNilFalse(t *testing.T) {
 	var l Link
-	assert.NoError(t, json.Unmarshal([]byte(`{"href": "a", "templated": null}`), &l))
+	require.NoError(t, json.Unmarshal([]byte(`{"href": "a", "templated": null}`), &l))
 	assert.False(t, l.Href.IsTemplated())
 }
 
 func TestLinkUnmarshalJSONMultipleLanguages(t *testing.T) {
 	var l Link
-	assert.NoError(t, json.Unmarshal([]byte(`{"href": "a", "language": ["fr", "en"]}`), &l))
+	require.NoError(t, json.Unmarshal([]byte(`{"href": "a", "language": ["fr", "en"]}`), &l))
 	assert.Equal(t, Link{Href: MustNewHREFFromString("a", false), Languages: []string{"fr", "en"}}, l)
 }
 
@@ -129,31 +130,31 @@ func TestLinkUnmarshalJSONRequiresHref(t *testing.T) {
 
 func TestLinkUnmarshalJSONRequiresPositiveWidth(t *testing.T) {
 	var l Link
-	assert.NoError(t, json.Unmarshal([]byte(`{"href": "a", "width": -20}`), &l))
+	require.NoError(t, json.Unmarshal([]byte(`{"href": "a", "width": -20}`), &l))
 	assert.Equal(t, l.Width, uint(0))
 }
 
 func TestLinkUnmarshalJSONRequiresPositiveHeight(t *testing.T) {
 	var l Link
-	assert.NoError(t, json.Unmarshal([]byte(`{"href": "a", "height": -20}`), &l))
+	require.NoError(t, json.Unmarshal([]byte(`{"href": "a", "height": -20}`), &l))
 	assert.Equal(t, l.Height, uint(0))
 }
 
 func TestLinkUnmarshalJSONRequiresPositiveBitrate(t *testing.T) {
 	var l Link
-	assert.NoError(t, json.Unmarshal([]byte(`{"href": "a", "bitrate": -20}`), &l))
+	require.NoError(t, json.Unmarshal([]byte(`{"href": "a", "bitrate": -20}`), &l))
 	assert.Equal(t, l.Bitrate, float64(0))
 }
 
 func TestLinkUnmarshalJSONRequiresPositiveDuration(t *testing.T) {
 	var l Link
-	assert.NoError(t, json.Unmarshal([]byte(`{"href": "a", "duration": -20}`), &l))
+	require.NoError(t, json.Unmarshal([]byte(`{"href": "a", "duration": -20}`), &l))
 	assert.Equal(t, l.Duration, float64(0))
 }
 
 func TestLinkUnmarshalJSONArray(t *testing.T) {
 	var ll []Link
-	assert.NoError(t, json.Unmarshal([]byte(`[
+	require.NoError(t, json.Unmarshal([]byte(`[
 		{"href": "http://child1"},
 		{"href": "http://child2"}
 	]`), &ll))
@@ -165,7 +166,7 @@ func TestLinkUnmarshalJSONArray(t *testing.T) {
 
 func TestLinkUnmarshalJSONNilArray(t *testing.T) {
 	ll, err := LinksFromJSONArray(nil)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.Equal(t, LinkList{}, ll)
 }
 
@@ -179,7 +180,7 @@ func TestLinkUnmarshalJSONArrayRefusesInvalidLinks(t *testing.T) {
 
 func TestLinkMinimalJSON(t *testing.T) {
 	b, err := json.Marshal(Link{Href: MustNewHREFFromString("http://href", false)})
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.JSONEq(t, `{"href": "http://href"}`, string(b))
 }
 
@@ -206,7 +207,7 @@ func TestLinkFullJSON(t *testing.T) {
 			{Href: MustNewHREFFromString("http://child2", false)},
 		},
 	})
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.JSONEq(t, `{
 		"href": "http://href",
 		"type": "application/pdf",
@@ -237,7 +238,7 @@ func TestLinkJSONArray(t *testing.T) {
 		{Href: MustNewHREFFromString("http://child1", false)},
 		{Href: MustNewHREFFromString("http://child2", false)},
 	})
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.JSONEq(t, `[
 		{"href": "http://child1"},
 		{"href": "http://child2"}

--- a/pkg/manifest/localized_string_test.go
+++ b/pkg/manifest/localized_string_test.go
@@ -5,18 +5,19 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestLocalizedStringUnmarshalJSONString(t *testing.T) {
 	var l LocalizedString
-	assert.NoError(t, json.Unmarshal([]byte("\"a string\""), &l))
+	require.NoError(t, json.Unmarshal([]byte("\"a string\""), &l))
 	assert.Equal(t, NewLocalizedStringFromString("a string"), l, "parsed JSON string should be equal to string")
 }
 
 func TestLocalizedStringUnmarshalJSONLocalizedStrings(t *testing.T) {
 	var l1 LocalizedString
 	var l2 LocalizedString
-	assert.NoError(t, json.Unmarshal([]byte(`{
+	require.NoError(t, json.Unmarshal([]byte(`{
 		"en": "a string",
 		"fr": "une chaîne"
 	}`), &l1))
@@ -38,7 +39,7 @@ func TestLocalizedStringUnmarshalNullJSON(t *testing.T) {
 func TestLocalizedStringOneTranslationNoLanguage(t *testing.T) {
 	l := NewLocalizedStringFromString("a string")
 	s, err := json.Marshal(&l)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.JSONEq(t, `"a string"`, string(s), "JSON of LocalizedString with default language should equal a JSON string of the value")
 }
 
@@ -48,7 +49,7 @@ func TestLocalizedStringJSON(t *testing.T) {
 	l.SetTranslation("fr", "une chaîne")
 	l.SetTranslation(UndefinedLanguage, "Surgh")
 	s, err := json.Marshal(&l)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.JSONEq(t, `{
 		"en": "a string",
 		"fr": "une chaîne",

--- a/pkg/manifest/locator_test.go
+++ b/pkg/manifest/locator_test.go
@@ -8,11 +8,12 @@ import (
 	"github.com/readium/go-toolkit/pkg/mediatype"
 	"github.com/readium/go-toolkit/pkg/util/url"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestLocatorUnmarshalMinimalJSON(t *testing.T) {
 	var l Locator
-	assert.NoError(t, json.Unmarshal([]byte(`{
+	require.NoError(t, json.Unmarshal([]byte(`{
 		"href": "http://locator",
 		"type": "text/html"
 	}`), &l))
@@ -24,7 +25,7 @@ func TestLocatorUnmarshalMinimalJSON(t *testing.T) {
 
 func TestLocatorUnmarshalJSON(t *testing.T) {
 	var l Locator
-	assert.NoError(t, json.Unmarshal([]byte(`{
+	require.NoError(t, json.Unmarshal([]byte(`{
 		"href": "http://locator",
 		"type": "text/html",
 		"title": "My Locator",
@@ -54,7 +55,7 @@ func TestLocatorMinimalJSON(t *testing.T) {
 		Href:      url.MustURLFromString("http://locator"),
 		MediaType: mediatype.HTML,
 	})
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.JSONEq(t, `{
 		"href": "http://locator",
 		"type": "text/html"
@@ -73,7 +74,7 @@ func TestLocatorJSON(t *testing.T) {
 			Highlight: "Excerpt",
 		},
 	})
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.JSONEq(t, `{
 		"href": "http://locator",
 		"type": "text/html",
@@ -89,13 +90,13 @@ func TestLocatorJSON(t *testing.T) {
 
 func TestLocationsUnmarshalMinimalJSON(t *testing.T) {
 	var l Locations
-	assert.NoError(t, json.Unmarshal([]byte(`{}`), &l))
+	require.NoError(t, json.Unmarshal([]byte(`{}`), &l))
 	assert.Equal(t, Locations{}, l)
 }
 
 func TestLocationsUnmarshalJSON(t *testing.T) {
 	var l Locations
-	assert.NoError(t, json.Unmarshal([]byte(`{
+	require.NoError(t, json.Unmarshal([]byte(`{
 		"fragments": ["p=4", "frag34"],
 		"progression": 0.74,
 		"totalProgression": 0.32,
@@ -115,7 +116,7 @@ func TestLocationsUnmarshalJSON(t *testing.T) {
 
 func TestLocationsUnmarshalSingleFragmentJSON(t *testing.T) {
 	var l Locations
-	assert.NoError(t, json.Unmarshal([]byte(`{"fragment": "frag34"}`), &l))
+	require.NoError(t, json.Unmarshal([]byte(`{"fragment": "frag34"}`), &l))
 	assert.Equal(t, Locations{
 		Fragments: []string{"frag34"},
 	}, l)
@@ -123,59 +124,59 @@ func TestLocationsUnmarshalSingleFragmentJSON(t *testing.T) {
 
 func TestLocationsUnmarshalIgnoresNegativePosition(t *testing.T) {
 	var l1 Locations
-	assert.NoError(t, json.Unmarshal([]byte(`{"position": 1}`), &l1))
+	require.NoError(t, json.Unmarshal([]byte(`{"position": 1}`), &l1))
 	assert.Equal(t, Locations{Position: extensions.Pointer[uint](1)}, l1)
 
 	var l2 Locations
-	assert.NoError(t, json.Unmarshal([]byte(`{"position": 0}`), &l2))
+	require.NoError(t, json.Unmarshal([]byte(`{"position": 0}`), &l2))
 	assert.Equal(t, Locations{}, l2)
 
 	var l3 Locations
-	assert.NoError(t, json.Unmarshal([]byte(`{"position": -1}`), &l3))
+	require.NoError(t, json.Unmarshal([]byte(`{"position": -1}`), &l3))
 	assert.Equal(t, Locations{}, l3)
 }
 
 func TestLocationsUnmarshalIgnoresProgressionOutOfRange(t *testing.T) {
 	var l1 Locations
-	assert.NoError(t, json.Unmarshal([]byte(`{"progression": 0.5}`), &l1))
+	require.NoError(t, json.Unmarshal([]byte(`{"progression": 0.5}`), &l1))
 	assert.Equal(t, Locations{Progression: extensions.Pointer(0.5)}, l1)
 
 	var l2 Locations
-	assert.NoError(t, json.Unmarshal([]byte(`{"progression": 0}`), &l2))
+	require.NoError(t, json.Unmarshal([]byte(`{"progression": 0}`), &l2))
 	assert.Equal(t, Locations{Progression: extensions.Pointer(0.0)}, l2)
 
 	var l3 Locations
-	assert.NoError(t, json.Unmarshal([]byte(`{"progression": 1}`), &l3))
+	require.NoError(t, json.Unmarshal([]byte(`{"progression": 1}`), &l3))
 	assert.Equal(t, Locations{Progression: extensions.Pointer(1.0)}, l3)
 
 	var l4 Locations
-	assert.NoError(t, json.Unmarshal([]byte(`{"progression": -0.5}`), &l4))
+	require.NoError(t, json.Unmarshal([]byte(`{"progression": -0.5}`), &l4))
 	assert.Equal(t, Locations{}, l4)
 
 	var l5 Locations
-	assert.NoError(t, json.Unmarshal([]byte(`{"progression": 1.2}`), &l5))
+	require.NoError(t, json.Unmarshal([]byte(`{"progression": 1.2}`), &l5))
 	assert.Equal(t, Locations{}, l5)
 }
 
 func TestLocationsUnmarshalIgnoresTotalProgressionOutOfRange(t *testing.T) {
 	var l1 Locations
-	assert.NoError(t, json.Unmarshal([]byte(`{"totalProgression": 0.5}`), &l1))
+	require.NoError(t, json.Unmarshal([]byte(`{"totalProgression": 0.5}`), &l1))
 	assert.Equal(t, Locations{TotalProgression: extensions.Pointer(0.5)}, l1)
 
 	var l2 Locations
-	assert.NoError(t, json.Unmarshal([]byte(`{"totalProgression": 0}`), &l2))
+	require.NoError(t, json.Unmarshal([]byte(`{"totalProgression": 0}`), &l2))
 	assert.Equal(t, Locations{TotalProgression: extensions.Pointer(0.0)}, l2)
 
 	var l3 Locations
-	assert.NoError(t, json.Unmarshal([]byte(`{"totalProgression": 1}`), &l3))
+	require.NoError(t, json.Unmarshal([]byte(`{"totalProgression": 1}`), &l3))
 	assert.Equal(t, Locations{TotalProgression: extensions.Pointer(1.0)}, l3)
 
 	var l4 Locations
-	assert.NoError(t, json.Unmarshal([]byte(`{"totalProgression": -0.5}`), &l4))
+	require.NoError(t, json.Unmarshal([]byte(`{"totalProgression": -0.5}`), &l4))
 	assert.Equal(t, Locations{}, l4)
 
 	var l5 Locations
-	assert.NoError(t, json.Unmarshal([]byte(`{"totalProgression": 1.2}`), &l5))
+	require.NoError(t, json.Unmarshal([]byte(`{"totalProgression": 1.2}`), &l5))
 	assert.Equal(t, Locations{}, l5)
 }
 
@@ -184,7 +185,7 @@ func TestLocationsMinimalJSON(t *testing.T) {
 		Href:      url.MustURLFromString("http://locator"),
 		MediaType: mediatype.HTML,
 	})
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	// Note: href and type are not omitted because they are required!
 	assert.JSONEq(t, `{"href": "http://locator", "type": "text/html"}`, string(s), "JSON objects should be equal")
 }
@@ -199,7 +200,7 @@ func TestLocationsJSON(t *testing.T) {
 			"other": "other-location",
 		},
 	})
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.JSONEq(t, `{
 		"fragments": ["p=4", "frag34"],
 		"progression": 0.74,
@@ -211,13 +212,13 @@ func TestLocationsJSON(t *testing.T) {
 
 func TestTextUnmarshalMinimalJSON(t *testing.T) {
 	var tx Text
-	assert.NoError(t, json.Unmarshal([]byte(`{}`), &tx))
+	require.NoError(t, json.Unmarshal([]byte(`{}`), &tx))
 	assert.Equal(t, Text{}, tx)
 }
 
 func TestTextUnmarshalJSON(t *testing.T) {
 	var tx Text
-	assert.NoError(t, json.Unmarshal([]byte(`{
+	require.NoError(t, json.Unmarshal([]byte(`{
 		"before": "Text before",
 		"highlight": "Highlighted text",
 		"after": "Text after"
@@ -231,7 +232,7 @@ func TestTextUnmarshalJSON(t *testing.T) {
 
 func TestTextMinimalJSON(t *testing.T) {
 	s, err := json.Marshal(Text{})
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.JSONEq(t, `{}`, string(s), "JSON objects should be equal")
 }
 
@@ -241,7 +242,7 @@ func TestTextJSON(t *testing.T) {
 		Highlight: "Highlighted text",
 		After:     "Text after",
 	})
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.JSONEq(t, `{
 		"before": "Text before",
 		"highlight": "Highlighted text",

--- a/pkg/manifest/manifest_test.go
+++ b/pkg/manifest/manifest_test.go
@@ -7,11 +7,12 @@ import (
 	"github.com/readium/go-toolkit/pkg/mediatype"
 	"github.com/readium/go-toolkit/pkg/util/url"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestManifestUnmarshalMinimalJSON(t *testing.T) {
 	var m Manifest
-	assert.NoError(t, json.Unmarshal([]byte(`{
+	require.NoError(t, json.Unmarshal([]byte(`{
 		"metadata": {"title": "Title"},
 		"links": [],
 		"readingOrder": []
@@ -28,7 +29,7 @@ func TestManifestUnmarshalMinimalJSON(t *testing.T) {
 
 func TestManifestUnmarshalFullJSON(t *testing.T) {
 	var m Manifest
-	assert.NoError(t, json.Unmarshal([]byte(`{
+	require.NoError(t, json.Unmarshal([]byte(`{
 		"@context": "https://readium.org/webpub-manifest/context.jsonld",
 		"metadata": {"title": "Title"},
 		"links": [
@@ -80,7 +81,7 @@ func TestManifestUnmarshalFullJSON(t *testing.T) {
 
 func TestManifestUnmarshalJSONContextAsArray(t *testing.T) {
 	var m Manifest
-	assert.NoError(t, json.Unmarshal([]byte(`{
+	require.NoError(t, json.Unmarshal([]byte(`{
 		"@context": ["context1", "context2"],
 		"metadata": {"title": "Title"},
 		"links": [
@@ -120,7 +121,7 @@ func TestManifestUnmarshalJSONRequiresMetadata(t *testing.T) {
 // {readingOrder} used to be {spine}, so we parse {spine} as a fallback.
 func TestManifestUnmarshalJSONSpinFallback(t *testing.T) {
 	var m Manifest
-	assert.NoError(t, json.Unmarshal([]byte(`{
+	require.NoError(t, json.Unmarshal([]byte(`{
 		"metadata": {"title": "Title"},
 		"links": [
 			{"href": "manifest.json", "rel": "self"}
@@ -209,7 +210,7 @@ func TestManifestMinimalJSON(t *testing.T) {
 		Links:        LinkList{},
 		ReadingOrder: LinkList{},
 	})
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	assert.JSONEq(t, `{
 		"@context": "https://readium.org/webpub-manifest/context.jsonld",
@@ -243,7 +244,7 @@ func TestManifestFullJSON(t *testing.T) {
 			}},
 		},
 	})
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	assert.JSONEq(t, `{
 		"@context": "https://readium.org/webpub-manifest/context.jsonld",
@@ -272,7 +273,7 @@ func TestManifestFullJSON(t *testing.T) {
 
 func TestManifestSelfLinkReplacedWhenPackaged(t *testing.T) {
 	var rm map[string]interface{}
-	assert.NoError(t, json.Unmarshal([]byte(`{
+	require.NoError(t, json.Unmarshal([]byte(`{
 		"metadata": {"title": "Title"},
 		"links": [
 			{"href": "manifest.json", "rel": ["self"], "templated": false}
@@ -280,7 +281,7 @@ func TestManifestSelfLinkReplacedWhenPackaged(t *testing.T) {
 		"readingOrder": []
 	}`), &rm))
 	m, err := ManifestFromJSON(rm, true)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	assert.Equal(t, Manifest{
 		Metadata: Metadata{
@@ -295,7 +296,7 @@ func TestManifestSelfLinkReplacedWhenPackaged(t *testing.T) {
 
 func TestManifestSelfLinkKeptWhenRemote(t *testing.T) {
 	var rm map[string]interface{}
-	assert.NoError(t, json.Unmarshal([]byte(`{
+	require.NoError(t, json.Unmarshal([]byte(`{
 		"metadata": {"title": "Title"},
 		"links": [
 			{"href": "manifest.json", "rel": ["self"], "templated": false}
@@ -303,7 +304,7 @@ func TestManifestSelfLinkKeptWhenRemote(t *testing.T) {
 		"readingOrder": []
 	}`), &rm))
 	m, err := ManifestFromJSON(rm, false)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	assert.Equal(t, Manifest{
 		Metadata: Metadata{
@@ -318,7 +319,7 @@ func TestManifestSelfLinkKeptWhenRemote(t *testing.T) {
 
 func TestManifestHrefResolvedToRoot(t *testing.T) {
 	var rm map[string]interface{}
-	assert.NoError(t, json.Unmarshal([]byte(`{
+	require.NoError(t, json.Unmarshal([]byte(`{
 		"metadata": {"title": "Title"},
 		"links": [
 			{"href": "http://example.com/manifest.json", "rel": ["self"], "templated": false}
@@ -329,7 +330,7 @@ func TestManifestHrefResolvedToRoot(t *testing.T) {
 	}`), &rm))
 
 	m, err := ManifestFromJSON(rm, true)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	m2 := m.NormalizeHREFsToSelf()
 
 	assert.Equal(t, "chap1.html", m2.ReadingOrder[0].Href.String())
@@ -337,7 +338,7 @@ func TestManifestHrefResolvedToRoot(t *testing.T) {
 
 func TestManifestHrefResolvedToRootRemotePackage(t *testing.T) {
 	var rm map[string]interface{}
-	assert.NoError(t, json.Unmarshal([]byte(`{
+	require.NoError(t, json.Unmarshal([]byte(`{
 		"metadata": {"title": "Title"},
 		"links": [
 			{"href": "http://example.com/directory/manifest.json", "rel": ["self"], "templated": false}
@@ -348,7 +349,7 @@ func TestManifestHrefResolvedToRootRemotePackage(t *testing.T) {
 	}`), &rm))
 
 	m, err := ManifestFromJSON(rm, false)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	m2 := m.NormalizeHREFsToSelf()
 
 	assert.Equal(t, "http://example.com/directory/chap1.html", m2.ReadingOrder[0].Href.String())

--- a/pkg/manifest/metadata_test.go
+++ b/pkg/manifest/metadata_test.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func init() {
@@ -14,7 +15,7 @@ func init() {
 
 func TestMetadataUnmarshalMinimalJSON(t *testing.T) {
 	var m Metadata
-	assert.NoError(t, json.Unmarshal([]byte(`{"title": "Title"}`), &m))
+	require.NoError(t, json.Unmarshal([]byte(`{"title": "Title"}`), &m))
 	assert.Equal(t, Metadata{LocalizedTitle: NewLocalizedStringFromString("Title")}, m, "parsed JSON object should be equal to Metadata object")
 }
 
@@ -26,15 +27,15 @@ func TestMetadataUnmarshalFullJSON(t *testing.T) {
 	})
 	lsa := NewLocalizedStringFromString("sort key")
 	modified, err := time.Parse(time.RFC3339Nano, "2001-01-01T12:36:27.000Z")
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	published, err := time.Parse(time.RFC3339Nano, "2001-01-02T12:36:27.000Z")
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	duration := float64(4.24)
 	numberOfPages := uint(240)
 	a11y := NewA11y()
 	a11y.ConformsTo = []A11yProfile{EPUBA11y10WCAG20A}
 
-	assert.NoError(t, json.Unmarshal([]byte(`{
+	require.NoError(t, json.Unmarshal([]byte(`{
 		"identifier": "1234",
 		"altIdentifier": ["https://example.com/identifier/12345", {
 			"value": "123456789",
@@ -152,7 +153,7 @@ func TestMetadataUnmarshalNilJSON(t *testing.T) {
 
 func TestMetadataUnmarshalJSONSingleProfile(t *testing.T) {
 	var m Metadata
-	assert.NoError(t, json.Unmarshal([]byte(`{
+	require.NoError(t, json.Unmarshal([]byte(`{
 		"title": "Title",
 		"conformsTo": "https://readium.org/webpub-manifest/profiles/epub"
 	}`), &m))
@@ -164,7 +165,7 @@ func TestMetadataUnmarshalJSONSingleProfile(t *testing.T) {
 
 func TestMetadataUnmarshalJSONSingleLanguage(t *testing.T) {
 	var m Metadata
-	assert.NoError(t, json.Unmarshal([]byte(`{
+	require.NoError(t, json.Unmarshal([]byte(`{
 		"title": "Title",
 		"language": "fr"
 	}`), &m))
@@ -181,7 +182,7 @@ func TestMetadataUnmarshalJSONRequiresTitle(t *testing.T) {
 
 func TestMetadataUnmarshalJSONDurationPositive(t *testing.T) {
 	var m Metadata
-	assert.NoError(t, json.Unmarshal([]byte(`{"title": "Title", "duration": -20}`), &m))
+	require.NoError(t, json.Unmarshal([]byte(`{"title": "Title", "duration": -20}`), &m))
 	assert.Equal(t, Metadata{
 		LocalizedTitle: NewLocalizedStringFromString("Title"),
 	}, m)
@@ -189,7 +190,7 @@ func TestMetadataUnmarshalJSONDurationPositive(t *testing.T) {
 
 func TestMetadataUnmarshalJSONNumberOfPagesPositive(t *testing.T) {
 	var m Metadata
-	assert.NoError(t, json.Unmarshal([]byte(`{"title": "Title", "numberOfPages": -20}`), &m))
+	require.NoError(t, json.Unmarshal([]byte(`{"title": "Title", "numberOfPages": -20}`), &m))
 	assert.Equal(t, Metadata{
 		LocalizedTitle: NewLocalizedStringFromString("Title"),
 	}, m)
@@ -199,7 +200,7 @@ func TestMetadataMinimalJSON(t *testing.T) {
 	b, err := json.Marshal(Metadata{
 		LocalizedTitle: NewLocalizedStringFromString("Title"),
 	})
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.JSONEq(t, `{"title": "Title"}`, string(b))
 }
 
@@ -209,9 +210,9 @@ func TestMetadataFullJSON(t *testing.T) {
 		"fr": "Sous-titre",
 	})
 	modified, err := time.Parse(time.RFC3339Nano, "2001-01-01T12:36:27.123Z")
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	published, err := time.Parse(time.RFC3339Nano, "2001-01-02T12:36:27.000Z")
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	lsa := NewLocalizedStringFromStrings(map[string]string{
 		"en": "sort key",
 		"fr": "clé de tri",
@@ -281,7 +282,7 @@ func TestMetadataFullJSON(t *testing.T) {
 			"other-metadata2": []interface{}{float64(42)},
 		},
 	})
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	assert.JSONEq(t, `{
 		"identifier": "1234",

--- a/pkg/manifest/properties_test.go
+++ b/pkg/manifest/properties_test.go
@@ -5,23 +5,24 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestPropertiesUnmarshalNilJSON(t *testing.T) {
 	props, err := PropertiesFromJSON(nil)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.Equal(t, Properties{}, props)
 }
 
 func TestProperiesUnmarshalMinimalJSON(t *testing.T) {
 	var p Properties
-	assert.NoError(t, json.Unmarshal([]byte(`{}`), &p))
+	require.NoError(t, json.Unmarshal([]byte(`{}`), &p))
 	assert.Equal(t, Properties{}, p)
 }
 
 func TestPropertiesUnmarshalFullJSON(t *testing.T) {
 	var p Properties
-	assert.NoError(t, json.Unmarshal([]byte(`{
+	require.NoError(t, json.Unmarshal([]byte(`{
 		"other-property1": "value",
 		"other-property2": [42]
 	}`), &p))

--- a/pkg/manifest/subject_test.go
+++ b/pkg/manifest/subject_test.go
@@ -5,11 +5,12 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestSubjectUnmarshalJSONString(t *testing.T) {
 	s, err := SubjectFromJSON("Fantasy")
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	assert.Equal(t, &Subject{
 		LocalizedName: NewLocalizedStringFromString("Fantasy"),
@@ -18,7 +19,7 @@ func TestSubjectUnmarshalJSONString(t *testing.T) {
 
 func TestSubjectUnmarshalMinimalJSON(t *testing.T) {
 	var s Subject
-	assert.NoError(t, json.Unmarshal([]byte(`{"name":"Science Fiction"}`), &s))
+	require.NoError(t, json.Unmarshal([]byte(`{"name":"Science Fiction"}`), &s))
 
 	assert.Equal(t, &Subject{
 		LocalizedName: NewLocalizedStringFromString("Science Fiction"),
@@ -27,7 +28,7 @@ func TestSubjectUnmarshalMinimalJSON(t *testing.T) {
 
 func TestSubjectUnmarshalFullJSON(t *testing.T) {
 	var s Subject
-	assert.NoError(t, json.Unmarshal([]byte(`{
+	require.NoError(t, json.Unmarshal([]byte(`{
 		"name": "Science Fiction",
 		"sortAs": "science-fiction",
 		"scheme": "http://scheme",
@@ -53,7 +54,7 @@ func TestSubjectUnmarshalFullJSON(t *testing.T) {
 
 func TestSubjectUnmarshalNilJSON(t *testing.T) {
 	s, err := SubjectFromJSON(nil)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.Nil(t, s)
 }
 
@@ -64,7 +65,7 @@ func TestSubjectUnmarshalRequiresName(t *testing.T) {
 
 func TestSubjectUnmarshalJSONArray(t *testing.T) {
 	var ss []Subject
-	assert.NoError(t, json.Unmarshal([]byte(`[
+	require.NoError(t, json.Unmarshal([]byte(`[
 		"Fantasy",
 		{
 			"name": "Science Fiction",
@@ -83,13 +84,13 @@ func TestSubjectUnmarshalJSONArray(t *testing.T) {
 
 func TestSubjectUnmarshalNilJSONArray(t *testing.T) {
 	ss, err := SubjectFromJSONArray(nil)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.Equal(t, 0, len(ss))
 }
 
 func TestSubjectUnmarshalJSONArrayString(t *testing.T) {
 	ss, err := SubjectFromJSONArray("Fantasy")
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.Equal(t, []Subject{
 		{LocalizedName: NewLocalizedStringFromString("Fantasy")},
 	}, ss, "parsed JSON object should be equal to Subject object")
@@ -110,7 +111,7 @@ func TestSubjectMinimalJSON(t *testing.T) {
 	bin, err := json.Marshal(Subject{
 		LocalizedName: NewLocalizedStringFromString("Science Fiction"),
 	})
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.JSONEq(t, string(bin), `"Science Fiction"`)
 }
 
@@ -126,7 +127,7 @@ func TestSubjectFullJSON(t *testing.T) {
 			{Href: MustNewHREFFromString("pub2", false)},
 		},
 	})
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.JSONEq(t, string(bin), `{
 		"name": "Science Fiction",
 		"sortAs": "science-fiction",
@@ -146,7 +147,7 @@ func TestSubjectJSONArray(t *testing.T) {
 		LocalizedName: NewLocalizedStringFromString("Science Fiction"),
 		Scheme:        "http://scheme",
 	}})
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.JSONEq(t, string(bin), `[
 		"Fantasy",
 		{

--- a/pkg/manifest/tdm_test.go
+++ b/pkg/manifest/tdm_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestTDMFromJSON(t *testing.T) {
@@ -13,7 +14,7 @@ func TestTDMFromJSON(t *testing.T) {
 		"reservation": "all",
 	}
 	tdm, err := TDMFromJSON(rawJSON)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	assert.Equal(t, "https://provider.com/policies/policy.json", tdm.Policy)
 	assert.Equal(t, TDMReservationAll, tdm.Reservation)
@@ -22,7 +23,7 @@ func TestTDMFromJSON(t *testing.T) {
 		"reservation": "none",
 	}
 	tdm, err = TDMFromJSON(rawJSON)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	assert.Equal(t, "", tdm.Policy)
 	assert.Equal(t, TDMReservationNone, tdm.Reservation)
@@ -34,7 +35,7 @@ func TestTDMMarshalJSON(t *testing.T) {
 		Reservation: TDMReservationAll,
 	}
 	rawJSON, err := json.Marshal(tdm)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	expectedJSON := `{"policy":"https://provider.com/policies/policy.json","reservation":"all"}`
 	assert.JSONEq(t, expectedJSON, string(rawJSON))
@@ -43,7 +44,7 @@ func TestTDMMarshalJSON(t *testing.T) {
 		Reservation: TDMReservationNone,
 	}
 	rawJSON, err = json.Marshal(tdm)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	expectedJSON = `{"reservation":"none"}`
 	assert.JSONEq(t, expectedJSON, string(rawJSON))

--- a/pkg/mediatype/mediatype_test.go
+++ b/pkg/mediatype/mediatype_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"golang.org/x/text/encoding/unicode"
 )
 
@@ -16,7 +17,7 @@ func TestMediatypeErrorForInvalidTypes(t *testing.T) {
 
 func TestMediatypeToString(t *testing.T) {
 	mt, err := NewOfString("application/atom+xml;profile=opds-catalog")
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	// Note there is a space between the mediatype semicolon and params. This is the behavior
 	// of Go's mime formatter, and differs from the Kotlin implementation
 	assert.Equal(t, "application/atom+xml; profile=opds-catalog", mt.String(), "MediaType should render to this string")
@@ -24,91 +25,91 @@ func TestMediatypeToString(t *testing.T) {
 
 func TestMediatypeToStringIsNormalized(t *testing.T) {
 	mt, err := NewOfString("APPLICATION/ATOM+XML;PROFILE=OPDS-CATALOG   ;   a=0")
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.Equal(t, "application/atom+xml; a=0; profile=OPDS-CATALOG", mt.String(), "MediaType should have the correct final casing")
 
 	mt, err = NewOfString("application/atom+xml;a=0;b=1")
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.Equal(t, "application/atom+xml; a=0; b=1", mt.String(), "MediaType should output as it was input")
 
 	mt, err = NewOfString("application/atom+xml;b=1;a=0")
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.Equal(t, "application/atom+xml; a=0; b=1", mt.String(), "MediaType should have alphabetically sorted parameters")
 }
 
 func TestMediatypeGetType(t *testing.T) {
 	mt, err := NewOfString("application/atom+xml;profile=opds-catalog")
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.Equal(t, "application", mt.Type, "MediaType type should be equal to \"application\"")
 
 	mt, err = NewOfString("*/jpeg")
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.Equal(t, "*", mt.Type, "MediaType type should be equal to \"*\"")
 }
 
 func TestMediatypeGetSubtype(t *testing.T) {
 	mt, err := NewOfString("application/atom+xml;profile=opds-catalog")
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.Equal(t, "atom+xml", mt.SubType, "MediaType subtype should be equal to \"atom+xml\"")
 
 	mt, err = NewOfString("image/*")
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.Equal(t, "*", mt.SubType, "MediaType subtype should be equal to \"*\"")
 }
 
 func TestMediatypeGetParameters(t *testing.T) {
 	mt, err := NewOfString("application/atom+xml;type=entry;profile=opds-catalog")
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.Equal(t, map[string]string{"type": "entry", "profile": "opds-catalog"}, mt.Parameters, "MediaType parameters should match the given map")
 }
 
 func TestMediatypeGetEmptyParameters(t *testing.T) {
 	mt, err := NewOfString("application/atom+xml")
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.True(t, len(mt.Parameters) == 0, "MediaType should have no parameters in its map")
 }
 
 func TestMediatypeGetParametersWithWhitespaces(t *testing.T) {
 	mt, err := NewOfString("application/atom+xml    ;    type=entry   ;    profile=opds-catalog   ")
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.Equal(t, map[string]string{"type": "entry", "profile": "opds-catalog"}, mt.Parameters, "MediaType parameters should match the given map")
 }
 
 func TestMediatypeGetStructuredSyntaxSuffix(t *testing.T) {
 	mt, err := NewOfString("foo/bar")
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.Empty(t, mt.StructuredSyntaxSuffix(), "MediaType should have no structured syntax suffix")
 
 	mt, err = NewOfString("application/zip")
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.Empty(t, mt.StructuredSyntaxSuffix(), "MediaType should have no structured syntax suffix")
 
 	mt, err = NewOfString("application/epub+zip")
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.Equal(t, "+zip", mt.StructuredSyntaxSuffix(), "structured syntax suffix should be \"+zip\"")
 
 	mt, err = NewOfString("foo/bar+json+zip")
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.Equal(t, "+zip", mt.StructuredSyntaxSuffix(), "structured syntax suffix should be \"+zip\"")
 }
 
 func TestMediatypeGetCharset(t *testing.T) {
 	mt, err := NewOfString("text/html")
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.Nil(t, mt.Charset(), "MediaType should have no charset")
 
 	mt, err = NewOfString("text/html;charset=utf-8")
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.Equal(t, unicode.UTF8, mt.Charset(), "charset should be utf-8")
 
 	mt, err = NewOfString("text/html;charset=utf-16")
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.Equal(t, unicode.UTF16(unicode.LittleEndian, unicode.IgnoreBOM), mt.Charset(), "charset should be utf-16 le (ignore bom)")
 }
 
 func TestMediatypeAllLowercased(t *testing.T) {
 	mt, err := NewOfString("APPLICATION/ATOM+XML;PROFILE=OPDS-CATALOG")
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.Equal(t, "application", mt.Type, "type should be lowercased")
 	assert.Equal(t, "atom+xml", mt.SubType, "subtype should be lowercased")
 	assert.Equal(t, map[string]string{"profile": "OPDS-CATALOG"}, mt.Parameters, "parameter keys should be lowercased")
@@ -116,76 +117,76 @@ func TestMediatypeAllLowercased(t *testing.T) {
 
 func TestMediatypeChartsetValueIsUppercased(t *testing.T) {
 	mt, err := NewOfString("text/html;charset=utf-8")
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.Equal(t, "UTF-8", mt.Parameters["charset"], "charset value should be uppercased")
 }
 
 func TestMediatypeCharsetValueCanonicalized(t *testing.T) {
 	mt, err := NewOfString("text/html;charset=ascii")
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.Equal(t, "WINDOWS-1252", mt.Parameters["charset"], "charset should be WINDOWS-1252, the ascii equivalent")
 
 	mt, err = NewOfString("text/html;charset=unknown")
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.Equal(t, "UNKNOWN", mt.Parameters["charset"], "charset should be unknown")
 }
 
 func TestMediatypeCanonicalize(t *testing.T) {
 	mt1, err := New("text/html", "", "html")
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	mt2, err := NewOfString("text/html;charset=utf-8")
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.Equal(t, &mt1, mt2.CanonicalMediaType())
 
 	mt1, err = NewOfString("application/atom+xml;profile=opds-catalog")
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	mt2, err = NewOfString("application/atom+xml;profile=opds-catalog;charset=utf-8")
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.Equal(t, &mt1, mt2.CanonicalMediaType())
 
 	mt1, err = NewOfString("application/unknown;charset=utf-8")
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	mt2, err = NewOfString("application/unknown;charset=utf-8")
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.Equal(t, &mt1, mt2.CanonicalMediaType())
 }
 
 func TestMediatypeEquality(t *testing.T) {
 	mt1, err := NewOfString("application/atom+xml")
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	mt2, err := NewOfString("application/atom+xml")
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.Equal(t, mt1, mt2)
 
 	mt1, err = NewOfString("application/atom+xml;profile=opds-catalog")
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	mt2, err = NewOfString("application/atom+xml;profile=opds-catalog")
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.Equal(t, mt1, mt2)
 
 	mt1, err = NewOfString("application/atom+xml")
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	mt2, err = NewOfString("application/atom")
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.NotEqual(t, mt1, mt2)
 
 	mt1, err = NewOfString("application/atom+xml")
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	mt2, err = NewOfString("text/atom+xml")
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.NotEqual(t, mt1, mt2)
 
 	mt1, err = NewOfString("application/atom+xml;profile=opds-catalog")
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	mt2, err = NewOfString("application/atom+xml")
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.NotEqual(t, mt1, mt2)
 
 	// Using the [Equal] function
 	mt1, err = NewOfString("text/html;charset=utf-8")
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	mt2, err = NewOfString("text/html")
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.False(t, mt1.Equal(&HTML))
 	assert.True(t, mt2.Equal(&HTML))
 	assert.False(t, mt1.Equal(&mt2))
@@ -195,159 +196,159 @@ func TestMediatypeEquality(t *testing.T) {
 // More specifically, equality ignores case of type, subtype and parameter names (but not parameter values!)
 func TestMediatypeEqualityIgnoresCases(t *testing.T) {
 	mt1, err := NewOfString("application/atom+xml;profile=opds-catalog")
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	mt2, err := NewOfString("APPLICATION/ATOM+XML;PROFILE=opds-catalog")
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.Equal(t, mt1, mt2)
 
 	mt1, err = NewOfString("application/atom+xml;profile=opds-catalog")
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	mt2, err = NewOfString("APPLICATION/ATOM+XML;PROFILE=OPDS-CATALOG")
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.NotEqual(t, mt1, mt2)
 }
 
 func TestMediatypeEqualityIgnoresParameterOrder(t *testing.T) {
 	mt1, err := NewOfString("application/atom+xml;type=entry;profile=opds-catalog")
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	mt2, err := NewOfString("application/atom+xml;profile=opds-catalog;type=entry")
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.Equal(t, mt1, mt2)
 }
 
 func TestMediatypeEqualityIgnoresCharsetCase(t *testing.T) {
 	mt1, err := NewOfString("application/atom+xml;charset=utf-8")
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	mt2, err := NewOfString("application/atom+xml;charset=UTF-8")
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.Equal(t, mt1, mt2, "charset parameter should be case-insensitive")
 }
 
 func TestMediatypeContainsEqual(t *testing.T) {
 	mt1, err := NewOfString("text/html;charset=utf-8")
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	mt2, err := NewOfString("text/html;charset=utf-8")
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.True(t, mt1.Contains(&mt2))
 }
 
 func TestMediatypeContainsParametersMatching(t *testing.T) {
 	mt1, err := NewOfString("text/html;charset=utf-8")
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	mt2, err := NewOfString("text/html;charset=ascii")
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.False(t, mt1.Contains(&mt2), "MediaTypes with different charsets should not be equal")
 
 	mt2, err = NewOfString("text/html")
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.False(t, mt1.Contains(&mt2), "MediaType with/without charset should not be interchangeable")
 }
 
 func TestMediatypeContainsIgnoresParameterOrder(t *testing.T) {
 	mt1, err := NewOfString("text/html;charset=utf-8;type=entry")
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	mt2, err := NewOfString("text/html;type=entry;charset=utf-8")
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.True(t, mt1.Contains(&mt2), "MediaTypes should ignore parameter order")
 }
 
 func TestMediatypeContainsIgnoresExtraParameters(t *testing.T) {
 	mt1, err := NewOfString("text/html")
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	mt2, err := NewOfString("text/html;charset=utf-8")
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.True(t, mt1.Contains(&mt2), "MediaType contains should ignore extra parameters")
 }
 
 func TestMediatypeContainsSupportsWildcards(t *testing.T) {
 	mt1, err := NewOfString("*/*")
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	mt2, err := NewOfString("text/html;charset=utf-8")
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.True(t, mt1.Contains(&mt2), "wildcards should contain anything")
 
 	mt1, err = NewOfString("text/*")
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.True(t, mt1.Contains(&mt2), "text/* should contain text/html")
 
 	mt2, err = NewOfString("application/zip")
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.False(t, mt1.Contains(&mt2))
 }
 
 func TestMediatypeContainsFromString(t *testing.T) {
 	mt, err := NewOfString("text/html;charset=utf-8")
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.True(t, mt.ContainsFromString("text/html;charset=utf-8"))
 }
 
 func TestMediatypeMatchesEqual(t *testing.T) {
 	mt1, err := NewOfString("text/html;charset=utf-8")
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	mt2, err := NewOfString("text/html;charset=utf-8")
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.True(t, mt1.Matches(&mt2), "two identical MediaTypes should match")
 }
 
 func TestMediatypeMatchesParametersMatching(t *testing.T) {
 	mt1, err := NewOfString("text/html;charset=utf-8")
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	mt2, err := NewOfString("text/html;charset=ascii")
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.False(t, mt1.Matches(&mt2), "MediaTypes with different charsets should not match")
 }
 
 func TestMediatypeMatchesIgnoresParameterOrder(t *testing.T) {
 	mt1, err := NewOfString("text/html;charset=utf-8;type=entry")
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	mt2, err := NewOfString("text/html;type=entry;charset=utf-8")
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.True(t, mt1.Matches(&mt2), "MediaType matches should ignore parameter order")
 }
 
 func TestMediatypeMatchesIgnoresExtraParameters(t *testing.T) {
 	mt1, err := NewOfString("text/html;charset=utf-8")
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	mt2, err := NewOfString("text/html;charset=utf-8;extra=param")
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.True(t, mt1.Matches(&mt2), "MediaType matches should ignore extra parameters")
 	assert.True(t, mt2.Matches(&mt1), "MediaType matches should ignore extra parameters")
 }
 
 func TestMediatypeMatchesSupportsWildcards(t *testing.T) {
 	mt1, err := NewOfString("*/*")
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	mt2, err := NewOfString("text/html;charset=utf-8")
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.True(t, mt2.Matches(&mt1), "anything should match with a wildcard MediaType")
 	assert.True(t, mt1.Matches(&mt2), "anything should match with a wildcard MediaType")
 
 	mt1, err = NewOfString("text/*")
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.True(t, mt2.Matches(&mt1), "text/html should match text/*")
 	assert.True(t, mt1.Matches(&mt2), "text/html should match text/*")
 
 	mt2, err = NewOfString("application/zip")
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.False(t, mt2.Matches(&mt1))
 	assert.False(t, mt1.Matches(&mt2))
 }
 
 func TestMediatypeMatchesFromString(t *testing.T) {
 	mt, err := NewOfString("text/html;charset=utf-8")
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.True(t, mt.MatchesFromString("text/html;charset=utf-8"))
 }
 
 func TestMediatypeMatchesAny(t *testing.T) {
 	mt1, err := NewOfString("text/html")
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	mt2, err := NewOfString("application/zip")
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	mt3, err := NewOfString("text/html;charset=utf-8")
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	mt4, err := NewOfString("text/plain;charset=utf-8")
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	assert.True(t, mt1.Matches(&mt2, &mt3))
 	assert.False(t, mt1.Matches(&mt2, &mt4))
@@ -357,53 +358,53 @@ func TestMediatypeMatchesAny(t *testing.T) {
 
 func TestMediatypeIsZIP(t *testing.T) {
 	mt, err := NewOfString("text/plain")
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.False(t, mt.IsZIP())
 
 	mt, err = NewOfString("application/zip")
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.True(t, mt.IsZIP())
 
 	mt, err = NewOfString("application/zip;charset=utf-8")
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.True(t, mt.IsZIP())
 
 	mt, err = NewOfString("application/epub+zip")
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.True(t, mt.IsZIP(), "EPUBs are ZIPs")
 
 	// These media types must be explicitly matched since they don't have any ZIP hint
 
 	mt, err = NewOfString("application/audiobook+lcp")
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.True(t, mt.IsZIP())
 
 	mt, err = NewOfString("application/pdf+lcp")
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.True(t, mt.IsZIP())
 }
 
 func TestMediatypeIsJSON(t *testing.T) {
 	mt, err := NewOfString("text/plain")
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.False(t, mt.IsJSON())
 
 	mt, err = NewOfString("application/json")
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.True(t, mt.IsJSON())
 
 	mt, err = NewOfString("application/json;charset=utf-8")
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.True(t, mt.IsJSON())
 
 	mt, err = NewOfString("application/opds+json")
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.True(t, mt.IsJSON())
 }
 
 func TestMediatypeIsOPDS(t *testing.T) {
 	mt, err := NewOfString("text/html")
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.False(t, mt.IsOPDS())
 
 	for _, r := range []string{
@@ -415,32 +416,32 @@ func TestMediatypeIsOPDS(t *testing.T) {
 		"application/opds-authentication+json",
 	} {
 		mt, err = NewOfString(r)
-		assert.NoError(t, err)
+		require.NoError(t, err)
 		assert.True(t, mt.IsOPDS(), r+" should be an OPDS document")
 	}
 }
 
 func TestMediatypeIsHTML(t *testing.T) {
 	mt, err := NewOfString("application/opds+json")
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.False(t, mt.IsHTML())
 
 	mt, err = NewOfString("text/html")
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.True(t, mt.IsHTML())
 
 	mt, err = NewOfString("application/xhtml+xml")
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.True(t, mt.IsHTML())
 
 	mt, err = NewOfString("text/html;charset=utf-8")
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.True(t, mt.IsHTML())
 }
 
 func TestMediatypeIsBitmap(t *testing.T) {
 	mt, err := NewOfString("text/html")
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.False(t, mt.IsBitmap())
 
 	for _, r := range []string{
@@ -455,64 +456,64 @@ func TestMediatypeIsBitmap(t *testing.T) {
 		"image/jxl",
 	} {
 		mt, err = NewOfString(r)
-		assert.NoError(t, err)
+		require.NoError(t, err)
 		assert.True(t, mt.IsBitmap(), r+" should be a bitmap")
 	}
 }
 
 func TestMediatypeIsAudio(t *testing.T) {
 	mt, err := NewOfString("text/html")
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.False(t, mt.IsAudio())
 
 	mt, err = NewOfString("audio/unknown")
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.True(t, mt.IsAudio())
 
 	mt, err = NewOfString("audio/mpeg;param=value")
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.True(t, mt.IsAudio())
 }
 
 func TestMediatypeIsVideo(t *testing.T) {
 	mt, err := NewOfString("text/html")
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.False(t, mt.IsVideo())
 
 	mt, err = NewOfString("video/unknown")
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.True(t, mt.IsVideo())
 
 	mt, err = NewOfString("video/mpeg;param=value")
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.True(t, mt.IsVideo())
 }
 
 func TestMediatypeIsRWPM(t *testing.T) {
 	mt, err := NewOfString("text/html")
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.False(t, mt.IsRwpm())
 
 	mt, err = NewOfString("application/audiobook+json")
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.True(t, mt.IsRwpm())
 
 	mt, err = NewOfString("application/divina+json")
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.True(t, mt.IsRwpm())
 
 	mt, err = NewOfString("application/webpub+json")
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.True(t, mt.IsRwpm())
 
 	mt, err = NewOfString("application/webpub+json;charset=utf-8")
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.True(t, mt.IsRwpm())
 }
 
 func TestMediatypeIsPublication(t *testing.T) {
 	mt, err := NewOfString("text/html")
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.False(t, mt.IsPublication())
 
 	for _, r := range []string{
@@ -533,7 +534,7 @@ func TestMediatypeIsPublication(t *testing.T) {
 		"application/x.readium.zab+zip",
 	} {
 		mt, err = NewOfString(r)
-		assert.NoError(t, err)
+		require.NoError(t, err)
 		assert.True(t, mt.IsPublication(), r+" should be a publication")
 	}
 }

--- a/pkg/mediatype/sniffer_test.go
+++ b/pkg/mediatype/sniffer_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestSnifferIgnoresExtensionCase(t *testing.T) {
@@ -37,47 +38,47 @@ CBZ sniffing is implemented below as a temporary alternative.
 
 func TestSnifferFromFile(t *testing.T) {
 	testAudiobook, err := os.Open(filepath.Join("testdata", "audiobook.json"))
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	defer testAudiobook.Close()
 	assert.Equal(t, &ReadiumAudiobookManifest, OfFileOnly(testAudiobook))
 }
 
 func TestSnifferFromBytes(t *testing.T) {
 	testAudiobook, err := os.Open(filepath.Join("testdata", "audiobook.json"))
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	testAudiobookBytes, err := io.ReadAll(testAudiobook)
 	testAudiobook.Close()
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.Equal(t, &ReadiumAudiobookManifest, MediaTypeOfBytesOnly(testAudiobookBytes))
 }
 */
 
 func TestSnifferFromFile(t *testing.T) {
 	testCbz, err := os.Open(filepath.Join("testdata", "cbz.unknown"))
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	defer testCbz.Close()
 	assert.Equal(t, &CBZ, OfFileOnly(t.Context(), testCbz), "test CBZ should be identified by heavy Sniffer")
 }
 
 func TestSnifferFromBytes(t *testing.T) {
 	testCbz, err := os.Open(filepath.Join("testdata", "cbz.unknown"))
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	testCbzBytes, err := io.ReadAll(testCbz)
 	testCbz.Close()
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.Equal(t, &CBZ, OfBytesOnly(t.Context(), testCbzBytes), "test CBZ's bytes should be identified by heavy Sniffer")
 }
 
 func TestSnifferUnknownFormat(t *testing.T) {
 	assert.Nil(t, OfString("invalid"), "\"invalid\" MediaType should be unsniffable")
 	unknownFile, err := os.Open(filepath.Join("testdata", "unknown"))
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.Nil(t, OfFileOnly(t.Context(), unknownFile), "MediaType of unknown file should be unsniffable")
 }
 
 func TestSnifferValidMediaTypeFallback(t *testing.T) {
 	expected, err := NewOfString("fruit/grapes")
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.Equal(t, &expected, OfString("fruit/grapes"), "valid MediaType should be sniffable")
 	assert.Equal(t, &expected, Of([]string{"invalid", "fruit/grapes"}, nil, Sniffers), "valid MediaType should be discoverable from provided list")
 	assert.Equal(t, &expected, Of([]string{"fruit/grapes", "vegetable/brocoli"}, nil, Sniffers), "valid MediaType should be discoverable from provided list")
@@ -118,7 +119,7 @@ func TestSniffCBZ(t *testing.T) {
 	assert.Equal(t, &CBZ, OfString("application/x-cbr"))
 
 	testCbz, err := os.Open(filepath.Join("testdata", "cbz.unknown"))
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	defer testCbz.Close()
 	assert.Equal(t, &CBZ, OfFileOnly(t.Context(), testCbz))
 }
@@ -141,7 +142,7 @@ func TestSniffEPUB(t *testing.T) {
 	assert.Equal(t, &EPUB, OfString("application/epub+zip"))
 
 	testEpub, err := os.Open(filepath.Join("testdata", "epub.unknown"))
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	defer testEpub.Close()
 	assert.Equal(t, &EPUB, OfFileOnly(t.Context(), testEpub))
 }
@@ -157,7 +158,7 @@ func TestSniffHTML(t *testing.T) {
 	assert.Equal(t, &HTML, OfString("text/html"))
 
 	testHtml, err := os.Open(filepath.Join("testdata", "html.unknown"))
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	defer testHtml.Close()
 	assert.Equal(t, &HTML, OfFileOnly(t.Context(), testHtml))
 }
@@ -168,7 +169,7 @@ func TestSniffXHTML(t *testing.T) {
 	assert.Equal(t, &XHTML, OfString("application/xhtml+xml"))
 
 	testXHtml, err := os.Open(filepath.Join("testdata", "xhtml.unknown"))
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	defer testXHtml.Close()
 	assert.Equal(t, &XHTML, OfFileOnly(t.Context(), testXHtml))
 }
@@ -192,7 +193,7 @@ func TestSniffOPDS1Feed(t *testing.T) {
 	assert.Equal(t, &OPDS1, OfString("application/atom+xml;profile=opds-catalog"))
 
 	testOPDS1Feed, err := os.Open(filepath.Join("testdata", "opds1-feed.unknown"))
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	defer testOPDS1Feed.Close()
 	assert.Equal(t, &OPDS1, OfFileOnly(t.Context(), testOPDS1Feed))
 }
@@ -201,7 +202,7 @@ func TestSniffOPDS1Entry(t *testing.T) {
 	assert.Equal(t, &OPDS1Entry, OfString("application/atom+xml;type=entry;profile=opds-catalog"))
 
 	testOPDS1Entry, err := os.Open(filepath.Join("testdata", "opds1-entry.unknown"))
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	defer testOPDS1Entry.Close()
 	assert.Equal(t, &OPDS1Entry, OfFileOnly(t.Context(), testOPDS1Entry))
 }
@@ -274,7 +275,7 @@ func TestSniffLCPLicenseDocument(t *testing.T) {
 	assert.Equal(t, &LCPLicenseDocument, OfString("application/vnd.readium.lcp.license.v1.0+json"))
 
 	testLCPLicenseDoc, err := os.Open(filepath.Join("testdata", "lcpl.unknown"))
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	defer testLCPLicenseDoc.Close()
 	assert.Equal(t, &LCPLicenseDocument, OfFileOnly(t.Context(), testLCPLicenseDoc))
 }
@@ -284,12 +285,12 @@ func TestSniffLPF(t *testing.T) {
 	assert.Equal(t, &LPF, OfString("application/lpf+zip"))
 
 	testLPF1, err := os.Open(filepath.Join("testdata", "lpf.unknown"))
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	defer testLPF1.Close()
 	assert.Equal(t, &LPF, OfFileOnly(t.Context(), testLPF1))
 
 	testLPF2, err := os.Open(filepath.Join("testdata", "lpf-index-html.unknown"))
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	defer testLPF2.Close()
 	assert.Equal(t, &LPF, OfFileOnly(t.Context(), testLPF2))
 }
@@ -299,7 +300,7 @@ func TestSniffPDF(t *testing.T) {
 	assert.Equal(t, &PDF, OfString("application/pdf"))
 
 	testPDF, err := os.Open(filepath.Join("testdata", "pdf.unknown"))
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	defer testPDF.Close()
 	assert.Equal(t, &PDF, OfFileOnly(t.Context(), testPDF))
 }
@@ -338,7 +339,7 @@ func TestSniffWebPubManifest(t *testing.T) {
 
 func TestSniffW3CWPUBManifest(t *testing.T) {
 	testW3CWPUB, err := os.Open(filepath.Join("testdata", "w3c-wpub.json"))
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	defer testW3CWPUB.Close()
 	assert.Equal(t, &W3CWPUBManifest, OfFileOnly(t.Context(), testW3CWPUB))
 }
@@ -347,7 +348,7 @@ func TestSniffZAB(t *testing.T) {
 	assert.Equal(t, &ZAB, OfExtension("zab"))
 
 	testZAB, err := os.Open(filepath.Join("testdata", "zab.unknown"))
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	defer testZAB.Close()
 	assert.Equal(t, &ZAB, OfFileOnly(t.Context(), testZAB))
 }
@@ -357,14 +358,14 @@ func TestSniffJSON(t *testing.T) {
 	assert.Equal(t, &JSON, OfString("application/json; charset=utf-8"))
 
 	testJSON, err := os.Open(filepath.Join("testdata", "any.json"))
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	defer testJSON.Close()
 	assert.Equal(t, &JSON, OfFileOnly(t.Context(), testJSON))
 }
 
 func TestSniffSystemMediaTypes(t *testing.T) {
 	err := mime.AddExtensionType(".xlsx", "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet")
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	xlsx, err := New("application/vnd.openxmlformats-officedocument.spreadsheetml.sheet", "XLSX", "xlsx")
 	assert.NoError(t, err)
 	assert.Equal(t, &xlsx, Of([]string{}, []string{"foobar", "xlsx"}, Sniffers))
@@ -376,12 +377,12 @@ func TestSniffSystemMediaTypes(t *testing.T) {
 // https://github.com/readium/r2-shared-kotlin/blob/develop/r2-shared/src/main/java/org/readium/r2/shared/util/mediatype/Sniffer.kt#L381
 func TestSniffSystemMediaTypesFromBytes(t *testing.T) {
 	err := mime.AddExtensionType("png", "image/png")
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	png, err := NewMediaType("image/png", "PNG", "png")
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	testPNG, err := os.Open(filepath.Join("testdata", "png.unknown"))
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	defer testPNG.Close()
 	assert.Equal(t, png, OfFileOnly(testPNG))
 }

--- a/pkg/parser/epub/deobfuscator_test.go
+++ b/pkg/parser/epub/deobfuscator_test.go
@@ -7,6 +7,7 @@ import (
 	"github.com/readium/go-toolkit/pkg/fetcher"
 	"github.com/readium/go-toolkit/pkg/manifest"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 const identifier = "urn:uuid:36d5078e-ff7d-468e-a5f3-f47c14b91f2f"
@@ -18,7 +19,7 @@ func withDeobfuscator(t *testing.T, href string, algorithm string, start, end in
 	// Cleartext font
 	clean, err := ft.Get(t.Context(), manifest.Link{Href: manifest.MustNewHREFFromString("deobfuscation/cut-cut.woff", false)}).Read(t.Context(), start, end)
 	if !assert.Nil(t, err) {
-		assert.NoError(t, err.Cause)
+		require.NoError(t, err.Cause)
 		f(nil, nil)
 		return
 	}
@@ -36,7 +37,7 @@ func withDeobfuscator(t *testing.T, href string, algorithm string, start, end in
 	}
 	obfu, err := NewDeobfuscator(identifier).Transform(ft.Get(t.Context(), link)).Read(t.Context(), start, end)
 	if !assert.Nil(t, err) {
-		assert.NoError(t, err.Cause)
+		require.NoError(t, err.Cause)
 		f(nil, nil)
 		return
 	}
@@ -45,7 +46,7 @@ func withDeobfuscator(t *testing.T, href string, algorithm string, start, end in
 	bbuff := new(bytes.Buffer)
 	_, err = NewDeobfuscator(identifier).Transform(ft.Get(t.Context(), link)).Stream(t.Context(), bbuff, start, end)
 	if !assert.Nil(t, err) {
-		assert.NoError(t, err.Cause)
+		require.NoError(t, err.Cause)
 		f(nil, nil)
 		return
 	}

--- a/pkg/parser/epub/metadata_test.go
+++ b/pkg/parser/epub/metadata_test.go
@@ -48,9 +48,9 @@ func loadMetadata(ctx context.Context, name string) (*manifest.Metadata, error) 
 
 func TestMetadataContributorDCCreatorDefaultsToAuthor(t *testing.T) {
 	m2, err := loadMetadata(t.Context(), "contributors-epub2")
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	m3, err := loadMetadata(t.Context(), "contributors-epub3")
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	contributor := manifest.Contributor{
 		LocalizedName: manifest.NewLocalizedStringFromString("Author 1"),
@@ -61,9 +61,9 @@ func TestMetadataContributorDCCreatorDefaultsToAuthor(t *testing.T) {
 
 func TestMetadataContributorDCPublisherIsPublisher(t *testing.T) {
 	m2, err := loadMetadata(t.Context(), "contributors-epub2")
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	m3, err := loadMetadata(t.Context(), "contributors-epub3")
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	contributor := manifest.Contributor{
 		LocalizedName: manifest.NewLocalizedStringFromString("Publisher 1"),
@@ -74,9 +74,9 @@ func TestMetadataContributorDCPublisherIsPublisher(t *testing.T) {
 
 func TestMetadataContributorDCContributorDefaultsToContributor(t *testing.T) {
 	m2, err := loadMetadata(t.Context(), "contributors-epub2")
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	m3, err := loadMetadata(t.Context(), "contributors-epub3")
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	contributor := manifest.Contributor{
 		LocalizedName: manifest.NewLocalizedStringFromString("Contributor 1"),
@@ -87,9 +87,9 @@ func TestMetadataContributorDCContributorDefaultsToContributor(t *testing.T) {
 
 func TestMetadataContributorUnknownRolesIgnored(t *testing.T) {
 	m2, err := loadMetadata(t.Context(), "contributors-epub2")
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	m3, err := loadMetadata(t.Context(), "contributors-epub3")
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	contributor := manifest.Contributor{
 		LocalizedName: manifest.NewLocalizedStringFromString("Contributor 2"),
@@ -101,9 +101,9 @@ func TestMetadataContributorUnknownRolesIgnored(t *testing.T) {
 
 func TestMetadataContributorFileAsParsed(t *testing.T) {
 	m2, err := loadMetadata(t.Context(), "contributors-epub2")
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	m3, err := loadMetadata(t.Context(), "contributors-epub3")
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	lsa := manifest.NewLocalizedStringFromString("Sorting Key")
 	contributor := manifest.Contributor{
@@ -117,7 +117,7 @@ func TestMetadataContributorFileAsParsed(t *testing.T) {
 func TestMetadataContributorLocalizedParsed(t *testing.T) {
 	// EPUB 3 only
 	m3, err := loadMetadata(t.Context(), "contributors-epub3")
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	assert.Contains(t, m3.Contributors, manifest.Contributor{
 		LocalizedName: manifest.NewLocalizedStringFromStrings(map[string]string{
@@ -130,7 +130,7 @@ func TestMetadataContributorLocalizedParsed(t *testing.T) {
 func TestMetadataContributorOnlyFirstRoleConsidered(t *testing.T) {
 	// EPUB 3 only
 	m3, err := loadMetadata(t.Context(), "contributors-epub3")
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	contributor := manifest.Contributor{
 		LocalizedName: manifest.NewLocalizedStringFromString("Cameleon"),
@@ -143,7 +143,7 @@ func TestMetadataContributorOnlyFirstRoleConsidered(t *testing.T) {
 func TestMetadataContributorMediaOverlaysNarrator(t *testing.T) {
 	// EPUB 3 only
 	m3, err := loadMetadata(t.Context(), "contributors-epub3")
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	assert.Contains(t, m3.Narrators, manifest.Contributor{
 		LocalizedName: manifest.NewLocalizedStringFromString("Media Overlays Narrator"),
@@ -152,9 +152,9 @@ func TestMetadataContributorMediaOverlaysNarrator(t *testing.T) {
 
 func TestMetadataContributorAuthor(t *testing.T) {
 	m2, err := loadMetadata(t.Context(), "contributors-epub2")
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	m3, err := loadMetadata(t.Context(), "contributors-epub3")
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	contributor := manifest.Contributor{
 		LocalizedName: manifest.NewLocalizedStringFromString("Author 2"),
@@ -166,9 +166,9 @@ func TestMetadataContributorAuthor(t *testing.T) {
 
 func TestMetadataContributorPublisher(t *testing.T) {
 	m2, err := loadMetadata(t.Context(), "contributors-epub2")
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	m3, err := loadMetadata(t.Context(), "contributors-epub3")
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	contributor := manifest.Contributor{
 		LocalizedName: manifest.NewLocalizedStringFromString("Publisher 2"),
@@ -180,9 +180,9 @@ func TestMetadataContributorPublisher(t *testing.T) {
 
 func TestMetadataContributorTranslator(t *testing.T) {
 	m2, err := loadMetadata(t.Context(), "contributors-epub2")
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	m3, err := loadMetadata(t.Context(), "contributors-epub3")
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	contributor := manifest.Contributor{
 		LocalizedName: manifest.NewLocalizedStringFromString("Translator"),
@@ -194,9 +194,9 @@ func TestMetadataContributorTranslator(t *testing.T) {
 
 func TestMetadataContributorArtist(t *testing.T) {
 	m2, err := loadMetadata(t.Context(), "contributors-epub2")
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	m3, err := loadMetadata(t.Context(), "contributors-epub3")
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	contributor := manifest.Contributor{
 		LocalizedName: manifest.NewLocalizedStringFromString("Artist"),
@@ -208,9 +208,9 @@ func TestMetadataContributorArtist(t *testing.T) {
 
 func TestMetadataContributorIllustrator(t *testing.T) {
 	m2, err := loadMetadata(t.Context(), "contributors-epub2")
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	m3, err := loadMetadata(t.Context(), "contributors-epub3")
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	contributor := manifest.Contributor{
 		LocalizedName: manifest.NewLocalizedStringFromString("Illustrator"),
@@ -222,9 +222,9 @@ func TestMetadataContributorIllustrator(t *testing.T) {
 
 func TestMetadataContributorColorist(t *testing.T) {
 	m2, err := loadMetadata(t.Context(), "contributors-epub2")
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	m3, err := loadMetadata(t.Context(), "contributors-epub3")
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	contributor := manifest.Contributor{
 		LocalizedName: manifest.NewLocalizedStringFromString("Colorist"),
@@ -236,9 +236,9 @@ func TestMetadataContributorColorist(t *testing.T) {
 
 func TestMetadataContributorNarrator(t *testing.T) {
 	m2, err := loadMetadata(t.Context(), "contributors-epub2")
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	m3, err := loadMetadata(t.Context(), "contributors-epub3")
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	contributor := manifest.Contributor{
 		LocalizedName: manifest.NewLocalizedStringFromString("Narrator"),
@@ -250,9 +250,9 @@ func TestMetadataContributorNarrator(t *testing.T) {
 
 func TestMetadataContributorsNoMoreThanNeeded(t *testing.T) {
 	m2, err := loadMetadata(t.Context(), "contributors-epub2")
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	m3, err := loadMetadata(t.Context(), "contributors-epub3")
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	assert.Len(t, m2.Authors, 2)
 	assert.Len(t, m2.Publishers, 2)
@@ -277,9 +277,9 @@ func TestMetadataContributorsNoMoreThanNeeded(t *testing.T) {
 
 func TestMetadataTitleParsed(t *testing.T) {
 	m2, err := loadMetadata(t.Context(), "titles-epub2")
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	m3, err := loadMetadata(t.Context(), "titles-epub3")
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	assert.Equal(t, manifest.NewLocalizedStringFromStrings(map[string]string{
 		"en": "Alice's Adventures in Wonderland",
@@ -293,7 +293,7 @@ func TestMetadataTitleParsed(t *testing.T) {
 func TestMetadataTitleSubtitleParsed(t *testing.T) {
 	// EPUB 3 only
 	m3, err := loadMetadata(t.Context(), "titles-epub3")
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	assert.Equal(t, manifest.NewLocalizedStringFromStrings(map[string]string{
 		"en-GB": "Alice returns to the magical world from her childhood adventure",
@@ -303,13 +303,13 @@ func TestMetadataTitleSubtitleParsed(t *testing.T) {
 
 func TestMetadataNoAccessibility(t *testing.T) {
 	m, err := loadMetadata(t.Context(), "version-default")
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.Nil(t, m.Accessibility)
 }
 
 func TestMetadataEPUB2Accessibility(t *testing.T) {
 	m, err := loadMetadata(t.Context(), "accessibility-epub2")
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	e := manifest.NewA11y()
 	e.ConformsTo = []manifest.A11yProfile{manifest.EPUBA11y11WCAG21AA, manifest.EPUBA11y11WCAG20AAA, manifest.EPUBA11y10WCAG20A}
 	e.Certification = &manifest.A11yCertification{
@@ -332,7 +332,7 @@ func TestMetadataEPUB2Accessibility(t *testing.T) {
 
 func TestMetadataEPUB2TDM(t *testing.T) {
 	m, err := loadMetadata(t.Context(), "tdm-epub2")
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.Equal(t, &manifest.TDM{
 		Policy:      "https://provider.com/policies/policy.json",
 		Reservation: manifest.TDMReservationAll,
@@ -341,7 +341,7 @@ func TestMetadataEPUB2TDM(t *testing.T) {
 
 func TestMetadataEPUB3Accessibility(t *testing.T) {
 	m, err := loadMetadata(t.Context(), "accessibility-epub3")
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	e := manifest.NewA11y()
 	e.ConformsTo = []manifest.A11yProfile{manifest.EPUBA11y11WCAG21AA, manifest.EPUBA11y11WCAG20AAA, manifest.EPUBA11y10WCAG20A}
 	e.Certification = &manifest.A11yCertification{
@@ -383,7 +383,7 @@ func TestMetadataEPUB3AccessibilityRefines(t *testing.T) {
 
 func TestMetadataEPUB3TDM(t *testing.T) {
 	m, err := loadMetadata(t.Context(), "tdm-epub3")
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.Equal(t, &manifest.TDM{
 		Policy:      "https://provider.com/policies/policy.json",
 		Reservation: manifest.TDMReservationAll,
@@ -392,9 +392,9 @@ func TestMetadataEPUB3TDM(t *testing.T) {
 
 func TestMetadataTitleFileAs(t *testing.T) {
 	m2, err := loadMetadata(t.Context(), "titles-epub2")
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	m3, err := loadMetadata(t.Context(), "titles-epub3")
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	assert.Equal(t, "Adventures", m2.SortAs())
 	assert.Equal(t, "Adventures", m3.SortAs())
@@ -403,7 +403,7 @@ func TestMetadataTitleFileAs(t *testing.T) {
 func TestMetadataTitleMainTakesPrecedence(t *testing.T) {
 	// EPUB 3 only
 	m3, err := loadMetadata(t.Context(), "title-main-precedence")
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	assert.Equal(t, "Main title takes precedence", m3.Title())
 }
@@ -411,7 +411,7 @@ func TestMetadataTitleMainTakesPrecedence(t *testing.T) {
 func TestMetadataTitleSelectedSubtitleHasLowestDisplaySeqProperty(t *testing.T) {
 	// EPUB 3 only
 	m3, err := loadMetadata(t.Context(), "title-multiple-subtitles")
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	assert.Equal(t, manifest.NewLocalizedStringFromStrings(map[string]string{
 		"en": "Subtitle 2",
@@ -421,7 +421,7 @@ func TestMetadataTitleSelectedSubtitleHasLowestDisplaySeqProperty(t *testing.T) 
 func TestMetadataSubjectLocalized(t *testing.T) {
 	// EPUB 3 only
 	m3, err := loadMetadata(t.Context(), "subjects-complex")
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	assert.Len(t, m3.Subjects, 1)
 	assert.Equal(t, manifest.NewLocalizedStringFromStrings(map[string]string{
@@ -433,7 +433,7 @@ func TestMetadataSubjectLocalized(t *testing.T) {
 func TestMetadataSubjectFileAs(t *testing.T) {
 	// EPUB 3 only
 	m3, err := loadMetadata(t.Context(), "subjects-complex")
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	assert.Len(t, m3.Subjects, 1)
 	assert.Equal(t, "occult", m3.Subjects[0].SortAs())
@@ -442,7 +442,7 @@ func TestMetadataSubjectFileAs(t *testing.T) {
 func TestMetadataSubjectCodeAndScheme(t *testing.T) {
 	// EPUB 3 only
 	m3, err := loadMetadata(t.Context(), "subjects-complex")
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	assert.Len(t, m3.Subjects, 1)
 	assert.Equal(t, "BISAC", m3.Subjects[0].Scheme)
@@ -452,7 +452,7 @@ func TestMetadataSubjectCodeAndScheme(t *testing.T) {
 func TestMetadataSubjectCommaSeparatedSplit(t *testing.T) {
 	// EPUB 3 only
 	m3, err := loadMetadata(t.Context(), "subjects-single")
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	assert.Contains(t, m3.Subjects, manifest.Subject{LocalizedName: manifest.NewLocalizedStringFromString("apple")})
 	assert.Contains(t, m3.Subjects, manifest.Subject{LocalizedName: manifest.NewLocalizedStringFromString("banana")})
@@ -462,7 +462,7 @@ func TestMetadataSubjectCommaSeparatedSplit(t *testing.T) {
 func TestMetadataSubjectCommaSeparatedMultipleNotSplit(t *testing.T) {
 	// EPUB 3 only
 	m3, err := loadMetadata(t.Context(), "subjects-multiple")
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	assert.Contains(t, m3.Subjects, manifest.Subject{LocalizedName: manifest.NewLocalizedStringFromString("fiction")})
 	assert.Contains(t, m3.Subjects, manifest.Subject{LocalizedName: manifest.NewLocalizedStringFromString("apple; banana,  pear")})
@@ -470,45 +470,45 @@ func TestMetadataSubjectCommaSeparatedMultipleNotSplit(t *testing.T) {
 
 func TestMetadataDatePublished(t *testing.T) {
 	m2, err := loadMetadata(t.Context(), "dates-epub2")
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	m3, err := loadMetadata(t.Context(), "dates-epub3")
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	tx, err := time.Parse(time.RFC3339, "1865-07-04T00:00:00Z")
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	assert.Equal(t, &tx, m2.Published)
 	assert.Equal(t, &tx, m3.Published)
 
 	// Non-ISO date
 	m3notiso, err := loadMetadata(t.Context(), "dates-epub3-notiso")
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.Equal(t, time.Date(1865, time.January, 1, 0, 0, 0, 0, time.UTC), *m3notiso.Published)
 }
 
 func TestMetadataDateModified(t *testing.T) {
 	m2, err := loadMetadata(t.Context(), "dates-epub2")
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	m3, err := loadMetadata(t.Context(), "dates-epub3")
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	tx, err := time.Parse(time.RFC3339, "2012-04-02T12:47:00Z")
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	assert.Equal(t, &tx, m2.Modified)
 	assert.Equal(t, &tx, m3.Modified)
 
 	// Non-ISO date
 	m3notiso, err := loadMetadata(t.Context(), "dates-epub3-notiso")
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.Equal(t, time.Date(2012, time.April, 1, 0, 0, 0, 0, time.UTC), *m3notiso.Modified)
 }
 
 func TestMetadataConformsToProfileEPUB(t *testing.T) {
 	m2, err := loadMetadata(t.Context(), "contributors-epub2")
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	m3, err := loadMetadata(t.Context(), "contributors-epub3")
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	assert.Contains(t, m2.ConformsTo, manifest.ProfileEPUB)
 	assert.Contains(t, m3.ConformsTo, manifest.ProfileEPUB)
@@ -516,14 +516,14 @@ func TestMetadataConformsToProfileEPUB(t *testing.T) {
 
 func TestMetadataUniqueIdentifierParsed(t *testing.T) {
 	m3, err := loadMetadata(t.Context(), "identifier-unique")
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	assert.Equal(t, "urn:uuid:2", m3.Identifier)
 }
 
 func TestMetadataLayout(t *testing.T) {
 	m3, err := loadMetadata(t.Context(), "presentation-metadata")
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.Equal(t, manifest.LayoutFixed, m3.Layout)
 	assert.Equal(t, "scrolled-doc", m3.OtherMetadata["http://www.idpf.org/vocab/rendition/#flow"])
 	assert.Empty(t, m3.OtherMetadata["http://www.idpf.org/vocab/rendition/#layout"])
@@ -534,11 +534,11 @@ func TestMetadataLayout(t *testing.T) {
 func TestMetadataCoverLink(t *testing.T) {
 	// Note: not using loadMetadata
 	m2, err := loadPackageDoc(t.Context(), "cover-epub2")
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	m3, err := loadPackageDoc(t.Context(), "cover-epub3")
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	mm, err := loadPackageDoc(t.Context(), "cover-mix")
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	expected := &manifest.Link{
 		Href:      manifest.MustNewHREFFromString("OEBPS/cover.jpg", false),
@@ -557,7 +557,7 @@ func TestMetadataCrossRefinings(t *testing.T) {
 
 func TestMetadataOtherMetadata(t *testing.T) {
 	m3, err := loadMetadata(t.Context(), "meta-others")
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	assert.Equal(t, m3.OtherMetadata, map[string]interface{}{
 		VocabularyDCTerms + "source": []interface{}{
@@ -581,7 +581,7 @@ func TestMetadataOtherMetadata(t *testing.T) {
 func TestMetadataCollectionBasic(t *testing.T) {
 	// EPUB 3 only
 	m3, err := loadMetadata(t.Context(), "collections-epub3")
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	assert.Contains(t, m3.BelongsToCollections(), manifest.Collection{
 		LocalizedName: manifest.NewLocalizedStringFromStrings(map[string]string{
@@ -593,7 +593,7 @@ func TestMetadataCollectionBasic(t *testing.T) {
 func TestMetadataCollectionsWithUnknownTypeInBelongsTo(t *testing.T) {
 	// EPUB 3 only
 	m3, err := loadMetadata(t.Context(), "collections-epub3")
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	assert.Contains(t, m3.BelongsToCollections(), manifest.Collection{
 		LocalizedName: manifest.NewLocalizedStringFromStrings(map[string]string{
@@ -605,7 +605,7 @@ func TestMetadataCollectionsWithUnknownTypeInBelongsTo(t *testing.T) {
 func TestMetadataCollectionLocalizedSeries(t *testing.T) {
 	// EPUB 3 only
 	m3, err := loadMetadata(t.Context(), "collections-epub3")
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	assert.Contains(t, m3.BelongsToSeries(), manifest.Collection{
 		LocalizedName: manifest.NewLocalizedStringFromStrings(map[string]string{
@@ -619,9 +619,9 @@ func TestMetadataCollectionLocalizedSeries(t *testing.T) {
 
 func TestMetadataCollectionSeriesWithPosition(t *testing.T) {
 	m2, err := loadMetadata(t.Context(), "collections-epub2")
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	m3, err := loadMetadata(t.Context(), "collections-epub3")
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	expected := manifest.Collection{
 		LocalizedName: manifest.NewLocalizedStringFromStrings(map[string]string{

--- a/pkg/parser/epub/parser_encryption_test.go
+++ b/pkg/parser/epub/parser_encryption_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/readium/go-toolkit/pkg/manifest"
 	"github.com/readium/go-toolkit/pkg/util/url"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func loadEncryption(ctx context.Context, name string) (map[string]manifest.Encryption, error) {
@@ -46,19 +47,19 @@ var testEncMap = map[string]manifest.Encryption{
 
 func TestEncryptionParserNamespacePrefixes(t *testing.T) {
 	e, err := loadEncryption(t.Context(), "lcp-prefixes")
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.Equal(t, testEncMap, e)
 }
 
 func TestEncryptionParserDefaultNamespaces(t *testing.T) {
 	e, err := loadEncryption(t.Context(), "lcp-xmlns")
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.Equal(t, testEncMap, e)
 }
 
 func TestEncryptionParserUnknownRetrievalMethod(t *testing.T) {
 	e, err := loadEncryption(t.Context(), "unknown-method")
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.Equal(t, map[string]manifest.Encryption{
 		url.MustURLFromString("OEBPS/images/image.jpeg").String(): {
 			Algorithm: "http://www.w3.org/2001/04/xmlenc#kw-aes128",

--- a/pkg/parser/epub/parser_navdoc_test.go
+++ b/pkg/parser/epub/parser_navdoc_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/readium/go-toolkit/pkg/manifest"
 	"github.com/readium/go-toolkit/pkg/util/url"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func loadNavDoc(ctx context.Context, name string) (map[string]manifest.LinkList, error) {
@@ -24,7 +25,7 @@ func loadNavDoc(ctx context.Context, name string) (map[string]manifest.LinkList,
 
 func TestNavDocParserNondirectDescendantOfBody(t *testing.T) {
 	n, err := loadNavDoc(t.Context(), "nav-section")
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.Equal(t, manifest.LinkList{
 		{
 			Title: "Chapter 1",
@@ -35,7 +36,7 @@ func TestNavDocParserNondirectDescendantOfBody(t *testing.T) {
 
 func TestNavDocParserNewlinesTrimmedFromTitle(t *testing.T) {
 	n, err := loadNavDoc(t.Context(), "nav-titles")
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.Contains(t, n["toc"], manifest.Link{
 		Title: "A link with new lines splitting the text",
 		Href:  manifest.MustNewHREFFromString("OEBPS/xhtml/chapter1.xhtml", false),
@@ -44,7 +45,7 @@ func TestNavDocParserNewlinesTrimmedFromTitle(t *testing.T) {
 
 func TestNavDocParserSpacesTrimmedFromTitle(t *testing.T) {
 	n, err := loadNavDoc(t.Context(), "nav-titles")
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.Contains(t, n["toc"], manifest.Link{
 		Title: "A link with ignorable spaces",
 		Href:  manifest.MustNewHREFFromString("OEBPS/xhtml/chapter2.xhtml", false),
@@ -53,7 +54,7 @@ func TestNavDocParserSpacesTrimmedFromTitle(t *testing.T) {
 
 func TestNavDocParserNestestHTMLElementsAllowedInTitle(t *testing.T) {
 	n, err := loadNavDoc(t.Context(), "nav-titles")
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.Contains(t, n["toc"], manifest.Link{
 		Title: "A link with nested HTML elements",
 		Href:  manifest.MustNewHREFFromString("OEBPS/xhtml/chapter3.xhtml", false),
@@ -62,7 +63,7 @@ func TestNavDocParserNestestHTMLElementsAllowedInTitle(t *testing.T) {
 
 func TestNavDocParserEntryWithoutTitleOrChildrenIgnored(t *testing.T) {
 	n, err := loadNavDoc(t.Context(), "nav-titles")
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.NotContains(t, n["toc"], manifest.Link{
 		Title: "",
 		Href:  manifest.MustNewHREFFromString("OEBPS/xhtml/chapter4.xhtml", false),
@@ -71,7 +72,7 @@ func TestNavDocParserEntryWithoutTitleOrChildrenIgnored(t *testing.T) {
 
 func TestNavDocParserEntryWithoutLinkOrChildrenIgnored(t *testing.T) {
 	n, err := loadNavDoc(t.Context(), "nav-titles")
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.NotContains(t, n["toc"], manifest.Link{
 		Title: "An unlinked element without children must be ignored",
 		Href:  manifest.MustNewHREFFromString("#", false),
@@ -80,7 +81,7 @@ func TestNavDocParserEntryWithoutLinkOrChildrenIgnored(t *testing.T) {
 
 func TestNavDocParserHierarchicalItemsNotAllowed(t *testing.T) {
 	n, err := loadNavDoc(t.Context(), "nav-children")
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.Equal(t, manifest.LinkList{
 		{Title: "Introduction", Href: manifest.MustNewHREFFromString("OEBPS/xhtml/introduction.xhtml", false)},
 		{
@@ -104,13 +105,13 @@ func TestNavDocParserHierarchicalItemsNotAllowed(t *testing.T) {
 
 func TestNavDocParserEmptyDocAccepted(t *testing.T) {
 	n, err := loadNavDoc(t.Context(), "nav-empty")
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.Empty(t, n["toc"])
 }
 
 func TestNavDocParserTOC(t *testing.T) {
 	n, err := loadNavDoc(t.Context(), "nav-complex")
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.Equal(t, manifest.LinkList{
 		{Title: "Chapter 1", Href: manifest.MustNewHREFFromString("OEBPS/xhtml/chapter1.xhtml", false)},
 		{Title: "Chapter 2", Href: manifest.MustNewHREFFromString("OEBPS/xhtml/chapter2.xhtml", false)},
@@ -119,7 +120,7 @@ func TestNavDocParserTOC(t *testing.T) {
 
 func TestNavDocParserPageList(t *testing.T) {
 	n, err := loadNavDoc(t.Context(), "nav-complex")
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.Equal(t, manifest.LinkList{
 		{Title: "1", Href: manifest.MustNewHREFFromString("OEBPS/xhtml/chapter1.xhtml#page1", false)},
 		{Title: "2", Href: manifest.MustNewHREFFromString("OEBPS/xhtml/chapter1.xhtml#page2", false)},

--- a/pkg/parser/epub/parser_ncx_test.go
+++ b/pkg/parser/epub/parser_ncx_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/readium/go-toolkit/pkg/manifest"
 	"github.com/readium/go-toolkit/pkg/util/url"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func loadNcx(ctx context.Context, name string) (map[string]manifest.LinkList, error) {
@@ -23,7 +24,7 @@ func loadNcx(ctx context.Context, name string) (map[string]manifest.LinkList, er
 
 func TestNCXParserNewlinesTrimmedFromTitle(t *testing.T) {
 	n, err := loadNcx(t.Context(), "ncx-titles")
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.Contains(t, n["toc"], manifest.Link{
 		Title: "A link with new lines splitting the text",
 		Href:  manifest.MustNewHREFFromString("OEBPS/xhtml/chapter1.xhtml", false),
@@ -32,7 +33,7 @@ func TestNCXParserNewlinesTrimmedFromTitle(t *testing.T) {
 
 func TestNCXParserSpacesTrimmedFromTitle(t *testing.T) {
 	n, err := loadNcx(t.Context(), "ncx-titles")
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.Contains(t, n["toc"], manifest.Link{
 		Title: "A link with ignorable spaces",
 		Href:  manifest.MustNewHREFFromString("OEBPS/xhtml/chapter2.xhtml", false),
@@ -41,7 +42,7 @@ func TestNCXParserSpacesTrimmedFromTitle(t *testing.T) {
 
 func TestNCXParserEntryWithNoTitleOrChildrenIgnored(t *testing.T) {
 	n, err := loadNcx(t.Context(), "ncx-titles")
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.NotContains(t, n["toc"], manifest.Link{
 		Title: "",
 		Href:  manifest.MustNewHREFFromString("OEBPS/xhtml/chapter3.xhtml", false),
@@ -50,7 +51,7 @@ func TestNCXParserEntryWithNoTitleOrChildrenIgnored(t *testing.T) {
 
 func TestNCXParserUnlinkedEntriesWithoutChildrenIgnored(t *testing.T) {
 	n, err := loadNcx(t.Context(), "ncx-titles")
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.NotContains(t, n["toc"], manifest.Link{
 		Title: "An unlinked element without children must be ignored",
 		Href:  manifest.MustNewHREFFromString("#", false),
@@ -59,7 +60,7 @@ func TestNCXParserUnlinkedEntriesWithoutChildrenIgnored(t *testing.T) {
 
 func TestNCXParserHierarchicalItemsAllowed(t *testing.T) {
 	n, err := loadNcx(t.Context(), "ncx-children")
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.Equal(t, manifest.LinkList{
 		{Title: "Introduction", Href: manifest.MustNewHREFFromString("OEBPS/xhtml/introduction.xhtml", false)},
 		{
@@ -83,13 +84,13 @@ func TestNCXParserHierarchicalItemsAllowed(t *testing.T) {
 
 func TestNCXParserEmptyNCX(t *testing.T) {
 	n, err := loadNcx(t.Context(), "ncx-empty")
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.Nil(t, n["toc"])
 }
 
 func TestNCXParserTOC(t *testing.T) {
 	n, err := loadNcx(t.Context(), "ncx-complex")
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.Equal(t, manifest.LinkList{
 		{Title: "Chapter 1", Href: manifest.MustNewHREFFromString("OEBPS/xhtml/chapter1.xhtml", false)},
 		{Title: "Chapter 2", Href: manifest.MustNewHREFFromString("OEBPS/xhtml/chapter2.xhtml", false)},
@@ -98,7 +99,7 @@ func TestNCXParserTOC(t *testing.T) {
 
 func TestNCXParserPageList(t *testing.T) {
 	n, err := loadNcx(t.Context(), "ncx-complex")
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.Equal(t, manifest.LinkList{
 		{Title: "1", Href: manifest.MustNewHREFFromString("OEBPS/xhtml/chapter1.xhtml#page1", false)},
 		{Title: "2", Href: manifest.MustNewHREFFromString("OEBPS/xhtml/chapter1.xhtml#page2", false)},

--- a/pkg/parser/epub/parser_packagedoc_test.go
+++ b/pkg/parser/epub/parser_packagedoc_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/readium/go-toolkit/pkg/mediatype"
 	"github.com/readium/go-toolkit/pkg/util/url"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func loadPackageDoc(ctx context.Context, name string) (*manifest.Manifest, error) {
@@ -37,31 +38,31 @@ func loadPackageDoc(ctx context.Context, name string) (*manifest.Manifest, error
 
 func TestPackageDocReadingProgressionNoneIsAuto(t *testing.T) {
 	p, err := loadPackageDoc(t.Context(), "progression-none")
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.Equal(t, manifest.None, p.Metadata.ReadingProgression)
 }
 
 func TestPackageDocPageProgression(t *testing.T) {
 	p, err := loadPackageDoc(t.Context(), "progression-default")
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.Equal(t, manifest.None, p.Metadata.ReadingProgression)
 }
 
 func TestPackageDocPageProgressionLTR(t *testing.T) {
 	p, err := loadPackageDoc(t.Context(), "progression-ltr")
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.Equal(t, manifest.LTR, p.Metadata.ReadingProgression)
 }
 
 func TestPackageDocPageProgressionRTL(t *testing.T) {
 	p, err := loadPackageDoc(t.Context(), "progression-rtl")
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.Equal(t, manifest.RTL, p.Metadata.ReadingProgression)
 }
 
 func TestPackageDocLinkPropertiesContains(t *testing.T) {
 	p, err := loadPackageDoc(t.Context(), "links-properties")
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	ro := p.ReadingOrder
 	assert.Equal(t, []string{"mathml"}, ro[0].Properties.Contains())
 	assert.Equal(t, []string{"remote-resources"}, ro[1].Properties.Contains())
@@ -72,7 +73,7 @@ func TestPackageDocLinkPropertiesContains(t *testing.T) {
 
 func TestPackageDocLinkPropertiesRels(t *testing.T) {
 	p, err := loadPackageDoc(t.Context(), "links-properties")
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	ro := p.ReadingOrder
 	assert.Equal(t, manifest.Strings{"cover"}, p.Resources[0].Rels)
 	assert.Empty(t, ro[0].Rels)
@@ -84,7 +85,7 @@ func TestPackageDocLinkPropertiesRels(t *testing.T) {
 
 func TestPackageDocLinkPropertiesPresentation(t *testing.T) {
 	p, err := loadPackageDoc(t.Context(), "links-properties")
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	ro := p.ReadingOrder
 	assert.Equal(t, ro[0].Properties.Page(), manifest.PageRight)
 	assert.Equal(t, ro[2].Properties.Page(), manifest.PageCenter)
@@ -93,7 +94,7 @@ func TestPackageDocLinkPropertiesPresentation(t *testing.T) {
 
 func TestPackageDocLinkReadingOrder(t *testing.T) {
 	p, err := loadPackageDoc(t.Context(), "links")
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	assert.Equal(t, manifest.LinkList{
 		{
@@ -109,7 +110,7 @@ func TestPackageDocLinkReadingOrder(t *testing.T) {
 
 func TestPackageDocLinkResources(t *testing.T) {
 	p, err := loadPackageDoc(t.Context(), "links")
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	ft := mediatype.OfString("application/vnd.ms-opentype")
 

--- a/pkg/parser/epub/parser_smil_test.go
+++ b/pkg/parser/epub/parser_smil_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/readium/go-toolkit/pkg/manifest"
 	"github.com/readium/go-toolkit/pkg/util/url"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func loadSmil(ctx context.Context, name string) (*manifest.GuidedNavigationDocument, error) {
@@ -25,9 +26,7 @@ func loadSmil(ctx context.Context, name string) (*manifest.GuidedNavigationDocum
 
 func TestSMILDocTypicalAudio(t *testing.T) {
 	doc, err := loadSmil(t.Context(), "audio1")
-	if !assert.NoError(t, err) {
-		return
-	}
+	require.NoError(t, err)
 	assert.Empty(t, doc.Links)
 	if assert.Len(t, doc.Guided, 6) {
 		assert.Equal(t, "OEBPS/page1.xhtml#word0", doc.Guided[0].TextRef)
@@ -45,12 +44,8 @@ func TestSMILW3Examples(t *testing.T) {
 
 func TestSMILClipBoundaries(t *testing.T) {
 	doc, err := loadSmil(t.Context(), "audio-clip")
-	if !assert.NoError(t, err) {
-		return
-	}
-	if !assert.Len(t, doc.Guided, 3) {
-		return
-	}
+	require.NoError(t, err)
+	require.Len(t, doc.Guided, 3)
 	assert.Equal(t, "OEBPS/audio/page1.m4a#t=,0.84", doc.Guided[0].AudioRef)
 	assert.Equal(t, "OEBPS/audio/page1.m4a#t=0.84", doc.Guided[1].AudioRef)
 	assert.Equal(t, "OEBPS/audio/page1.m4a", doc.Guided[2].AudioRef)

--- a/pkg/parser/parser_image_test.go
+++ b/pkg/parser/parser_image_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/readium/go-toolkit/pkg/pub"
 	"github.com/readium/go-toolkit/pkg/util/url"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func withImageParser(t *testing.T, filepath string, f func(*pub.Builder)) {
@@ -17,9 +18,9 @@ func withImageParser(t *testing.T, filepath string, f func(*pub.Builder)) {
 	fet, err := a.CreateFetcher(t.Context(), asset.Dependencies{
 		ArchiveFactory: archive.NewArchiveFactory(),
 	}, "")
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	p, err := ImageParser{}.Parse(t.Context(), a, fet)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	f(p)
 }
 
@@ -37,9 +38,9 @@ func TestImageJPGAccepted(t *testing.T) {
 
 func TestImageConformsTo(t *testing.T) {
 	withImageParser(t, "./testdata/image/futuristic_tales.cbz", func(p *pub.Builder) {
-		assert.NotNil(t, p)
+		require.NotNil(t, p)
 		pub := p.Build()
-		assert.NotNil(t, pub)
+		require.NotNil(t, pub)
 
 		assert.Equal(t, pub.Manifest.Metadata.ConformsTo, manifest.Profiles{manifest.ProfileDivina})
 	})
@@ -47,9 +48,9 @@ func TestImageConformsTo(t *testing.T) {
 
 func TestImageReadingOrderAlphabetical(t *testing.T) {
 	withImageParser(t, "./testdata/image/futuristic_tales.cbz", func(p *pub.Builder) {
-		assert.NotNil(t, p)
+		require.NotNil(t, p)
 		pub := p.Build()
-		assert.NotNil(t, pub)
+		require.NotNil(t, pub)
 		base, _ := url.URLFromDecodedPath("Cory Doctorow's Futuristic Tales of the Here and Now/")
 
 		hrefs := make([]string, 0, len(pub.Manifest.ReadingOrder))
@@ -64,12 +65,12 @@ func TestImageReadingOrderAlphabetical(t *testing.T) {
 
 func TestImageCoverFirstItem(t *testing.T) {
 	withImageParser(t, "./testdata/image/futuristic_tales.cbz", func(p *pub.Builder) {
-		assert.NotNil(t, p)
+		require.NotNil(t, p)
 		pub := p.Build()
-		assert.NotNil(t, pub)
+		require.NotNil(t, pub)
 
 		coverItem := pub.Manifest.ReadingOrder.FirstWithRel("cover")
-		assert.NotNil(t, coverItem, "readingOrder should have an item with rel=cover")
+		require.NotNil(t, coverItem, "readingOrder should have an item with rel=cover")
 
 		u, _ := url.URLFromDecodedPath("Cory Doctorow's Futuristic Tales of the Here and Now/a-fc.jpg")
 		assert.Equal(t, manifest.NewHREF(u).String(), coverItem.Href.String())
@@ -78,9 +79,9 @@ func TestImageCoverFirstItem(t *testing.T) {
 
 func TestImageTitleBasedOnRoot(t *testing.T) {
 	withImageParser(t, "./testdata/image/futuristic_tales.cbz", func(p *pub.Builder) {
-		assert.NotNil(t, p)
+		require.NotNil(t, p)
 		pub := p.Build()
-		assert.NotNil(t, pub)
+		require.NotNil(t, pub)
 
 		assert.Equal(
 			t,

--- a/pkg/streamer/a11y_infer_test.go
+++ b/pkg/streamer/a11y_infer_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/readium/go-toolkit/pkg/mediatype"
 	"github.com/readium/go-toolkit/pkg/pub"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestReturnsAdditionalInferredA11yMetadata(t *testing.T) {
@@ -31,7 +32,7 @@ func TestReturnsAdditionalInferredA11yMetadata(t *testing.T) {
 	inferreddA11y.AccessModesSufficient = [][]manifest.A11yPrimaryAccessMode{{manifest.A11yPrimaryAccessModeTextual}}
 
 	res, err := inferA11yMetadataInPublicationManifest(context.TODO(), pub.New(m, nil, nil), nil)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.Equal(t, &inferreddA11y, res)
 
 	// Original manifest should not be modified.
@@ -62,7 +63,7 @@ func TestInferVisualAccessMode(t *testing.T) {
 func assertAccessMode(t *testing.T, accessMode manifest.A11yAccessMode, extension string, mt mediatype.MediaType) {
 	testManifest := func(m manifest.Manifest) {
 		res, err := inferA11yMetadataInPublicationManifest(context.TODO(), pub.New(m, nil, nil), nil)
-		assert.NoError(t, err)
+		require.NoError(t, err)
 		assert.NotNil(t, res)
 		assert.Contains(t, res.AccessModes, accessMode)
 	}
@@ -88,7 +89,7 @@ func TestInferTextualAccessModeAndAccessModeSufficientFromProfile(t *testing.T) 
 			},
 		}
 		res, err := inferA11yMetadataInPublicationManifest(context.TODO(), pub.New(m, nil, nil), nil)
-		assert.NoError(t, err)
+		require.NoError(t, err)
 		assert.NotNil(t, res)
 		assert.Contains(t, res.AccessModes, manifest.A11yAccessModeTextual)
 		assert.Contains(t, res.AccessModesSufficient, []manifest.A11yPrimaryAccessMode{manifest.A11yPrimaryAccessModeTextual})
@@ -104,7 +105,7 @@ func TestInferTextualAccessModeAndAccessModeSufficientFromProfile(t *testing.T) 
 func TestInferTextualAccessModeAndAccessModeSufficientFromLackOfMedia(t *testing.T) {
 	testManifest := func(contains bool, m manifest.Manifest) {
 		res, err := inferA11yMetadataInPublicationManifest(context.TODO(), pub.New(m, nil, nil), nil)
-		assert.NoError(t, err)
+		require.NoError(t, err)
 		assert.NotNil(t, res)
 		ams := []manifest.A11yPrimaryAccessMode{manifest.A11yPrimaryAccessModeTextual}
 
@@ -174,7 +175,7 @@ func TestDontInferTextualAccessModeAndAccessModeSufficientFromLackOfMediaForFXL(
 	}
 
 	res, err := inferA11yMetadataInPublicationManifest(context.TODO(), pub.New(m, nil, nil), nil)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.NotNil(t, res)
 	ams := []manifest.A11yPrimaryAccessMode{manifest.A11yPrimaryAccessModeTextual}
 	assert.NotContains(t, res.AccessModes, manifest.A11yAccessModeTextual)
@@ -212,13 +213,13 @@ func TestInferTextualAccessModeWithIgnoredImages(t *testing.T) {
 	f := fetcher.NewFileFetcher("file.png", "testdata/file.png")
 
 	res, err := inferA11yMetadataInPublicationManifest(context.TODO(), pub.New(m, f, nil), nil)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.NotContains(t, res.AccessModes, manifest.A11yAccessModeTextual)
 	assert.Contains(t, res.AccessModes, manifest.A11yAccessModeVisual)
 	assert.NotContains(t, res.AccessModesSufficient, []manifest.A11yPrimaryAccessMode{manifest.A11yPrimaryAccessModeTextual})
 
 	res, err = inferA11yMetadataInPublicationManifest(context.TODO(), pub.New(m, f, nil), testHash)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.Contains(t, res.AccessModes, manifest.A11yAccessModeTextual)
 	assert.Contains(t, res.AccessModes, manifest.A11yAccessModeVisual)
 	assert.Contains(t, res.AccessModesSufficient, []manifest.A11yPrimaryAccessMode{manifest.A11yPrimaryAccessModeTextual})
@@ -228,7 +229,7 @@ func TestInferTextualAccessModeWithIgnoredImages(t *testing.T) {
 func TestInferAuditoryAccessModeSufficient(t *testing.T) {
 	testManifest := func(contains bool, m manifest.Manifest) {
 		res, err := inferA11yMetadataInPublicationManifest(context.TODO(), pub.New(m, nil, nil), nil)
-		assert.NoError(t, err)
+		require.NoError(t, err)
 		if res == nil && !contains {
 			return
 		}
@@ -275,7 +276,7 @@ func TestInferAuditoryAccessModeSufficient(t *testing.T) {
 func TestInferVisualAccessModeSufficient(t *testing.T) {
 	testManifest := func(contains bool, m manifest.Manifest) {
 		res, err := inferA11yMetadataInPublicationManifest(context.TODO(), pub.New(m, nil, nil), nil)
-		assert.NoError(t, err)
+		require.NoError(t, err)
 		if res == nil && !contains {
 			return
 		}
@@ -387,7 +388,7 @@ func TestInferFeatureDisplayTransformability(t *testing.T) {
 		}
 
 		res, err := inferA11yMetadataInPublicationManifest(context.TODO(), pub.New(m, nil, nil), nil)
-		assert.NoError(t, err)
+		require.NoError(t, err)
 		assert.NotNil(t, res)
 		if contains {
 			assert.Contains(t, res.Features, manifest.A11yFeatureDisplayTransformability)
@@ -418,7 +419,7 @@ func TestInferFeatureSynchronizedAudioText(t *testing.T) {
 
 func assertFeature(t *testing.T, m manifest.Manifest, feature manifest.A11yFeature) {
 	res, err := inferA11yMetadataInPublicationManifest(context.TODO(), pub.New(m, nil, nil), nil)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.NotNil(t, res)
 	assert.Contains(t, res.Features, feature)
 }


### PR DESCRIPTION
Change assertions to utilize functions from `require` to stop tests immediately where subsequent assertions would make no sense.

Resolves #247